### PR TITLE
SAR-393/simple width fix

### DIFF
--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -39,11 +39,10 @@ function D3Chart({ displayData, colorMapping }) {
       .attr('transform', `translate(${margin.left},${margin.top})`);
 
     // Generates labels and context for x axis
-    const x = d3.scaleTime()
-      // What data we're measuring
+    const x = d3.scaleTime() // What data we're measuring
       .domain(d3.extent(displayData, (d) => parseDate(d.date.split('T')[0])))
       // The 'width' of the data
-      .range([0, width + margin.left]);
+      .range([0, width]);
 
     // X Axis labels and context
     svg.append('g')

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -22,7 +22,8 @@ function D3Chart({ displayData, colorMapping }) {
     bottom: 75,
     left: 30,
   };
-  const width = (window.innerWidth || document.body.clientWidth) - 100;
+  const widthBase = (window.innerWidth || document.body.clientWidth);
+  const width = widthBase - widthBase / 8;
   const height = 500;
   const tickCount = displayData.length / measureList.length;
 

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -22,8 +22,9 @@ function D3Chart({ displayData, colorMapping }) {
     bottom: 75,
     left: 30,
   };
+  const box = document.querySelector('.MuiGrid-item');
   const widthBase = (window.innerWidth || document.body.clientWidth);
-  const width = widthBase - widthBase / 6;
+  const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 200;
   const height = 500;
   const tickCount = displayData.length / measureList.length;
 

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -23,7 +23,7 @@ function D3Chart({ displayData, colorMapping }) {
     left: 30,
   };
   const widthBase = (window.innerWidth || document.body.clientWidth);
-  const width = widthBase - widthBase / 8;
+  const width = widthBase - widthBase / 6;
   const height = 500;
   const tickCount = displayData.length / measureList.length;
 

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -13,7 +13,8 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
   const margin = {
     top: 50, right: 30, bottom: 75, left: 30,
   };
-  const width = (window.innerWidth || document.body.clientWidth) - 100;
+  const widthBase = (window.innerWidth || document.body.clientWidth);
+  const width = widthBase - widthBase / 8;
   const height = 500;
   const tickCount = byLineDisplayData.length;
 

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -37,7 +37,7 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
     // What data we're measuring
       .domain(d3.extent(byLineDisplayData, (d) => parseDate(d.date.split('T')[0])))
     // The 'width' of the data
-      .range([0, width + margin.left]);
+      .range([0, width]);
 
     // X Axis labels and context
     svg.append('g')

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -14,7 +14,7 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
     top: 50, right: 30, bottom: 75, left: 30,
   };
   const widthBase = (window.innerWidth || document.body.clientWidth);
-  const width = widthBase - widthBase / 8;
+  const width = widthBase - widthBase / 6;
   const height = 500;
   const tickCount = byLineDisplayData.length;
 

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -13,8 +13,9 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
   const margin = {
     top: 50, right: 30, bottom: 75, left: 30,
   };
+  const box = document.querySelector('.MuiGrid-item');
   const widthBase = (window.innerWidth || document.body.clientWidth);
-  const width = widthBase - widthBase / 6;
+  const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 200;
   const height = 500;
   const tickCount = byLineDisplayData.length;
 


### PR DESCRIPTION
# Related Tickets

- [SAR-393](https://amida.atlassian.net/browse/SAR-393)

# How Things Worked (or Didn't) Before This PR

The SVG's border would overrun the box it was contained in within MUI, and it'd do it responsively, allowing data to be shoved off the side of the window. 

# How Things Work Now (And How to Test)

The SVG's border now responsively adapts to the screen size, and pushes itself inward by one hundred pixels left of the box element's size. Due to this being a problem with the SVG and not the CSS, it's entirely implemented in the graph's respective D3 files.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
