### PR TITLE
[SAR-415]: Handle NA value for trend

### DIFF
--- a/src/assets/styles/App.scss
+++ b/src/assets/styles/App.scss
@@ -8,6 +8,7 @@
 @use 'global';
 @use 'not-found';
 @use 'tab-panel';
+@use 'trend-display';
 @use 'rating-trends';
 
 @use 'colors';

--- a/src/assets/styles/_rating-trends.scss
+++ b/src/assets/styles/_rating-trends.scss
@@ -34,16 +34,12 @@ $block-class: 'rating-trends';
             margin: 1rem;
             padding: 1rem;
 
-            &__width-25 {
+            &--width-25 {
                 width: 25%;
             }
     
-            &__width-50 {
+            &--width-50 {
                 width: 50%;
-            }
-    
-            &__hide {
-                display: none;
             }
         }
 
@@ -59,7 +55,7 @@ $block-class: 'rating-trends';
             height: 46px;
         }
 
-        &__help {
+        &__help-icon {
             color: $gray-light;
             margin-left: 0.4rem;
             margin-top: 0.1rem;
@@ -98,25 +94,6 @@ $block-class: 'rating-trends';
             border: 1px solid $default-gray;
             padding: 1rem;
             border-radius: 0.25rem;
-        }
-
-        & &__percent-change {
-            margin-top: 1rem;
-            font-size: 2.5rem;
-            font-weight: 500;
-            color: $default-black;
-
-            &__positive {
-                color: $default-green;
-            }
-
-            &__negative {
-                color: $default-red;
-            }
-
-            &__hide {
-                display: none;
-            }
         }
     }
 }

--- a/src/assets/styles/_rating-trends.scss
+++ b/src/assets/styles/_rating-trends.scss
@@ -74,12 +74,6 @@ $block-class: 'rating-trends';
             margin-top: 0.4rem;
         }
 
-        &__border {
-            border: 1px solid $default-gray;
-            background-color: $default-gray;
-            height: auto;
-        }
-
         &__button-panel {
             display: flex;
             justify-content: flex-end;

--- a/src/assets/styles/_rating-trends.scss
+++ b/src/assets/styles/_rating-trends.scss
@@ -1,4 +1,5 @@
 $block-class: 'rating-trends';
+@import 'colors';
 
 @at-root {
     .#{$block-class} {
@@ -59,12 +60,12 @@ $block-class: 'rating-trends';
         }
 
         &__help {
-            color: #CFDFDC;
+            color: $gray-light;
             margin-left: 0.4rem;
             margin-top: 0.1rem;
 
             &:hover {
-                color: #1976D2;
+                color: $blue-light;
             }
         }
         
@@ -78,8 +79,8 @@ $block-class: 'rating-trends';
         }
 
         &__border {
-            border: 1px solid grey;
-            background-color: grey;
+            border: 1px solid $default-gray;
+            background-color: $default-gray;
             height: auto;
         }
 
@@ -91,10 +92,10 @@ $block-class: 'rating-trends';
         }
 
         & &__view-rating-details-button {
-            background-color: #1976D2;
+            background-color: $blue-light;
             color: #fff;
             font-weight: 600;
-            border: 1px solid grey;
+            border: 1px solid $default-gray;
             padding: 1rem;
             border-radius: 0.25rem;
         }
@@ -103,13 +104,14 @@ $block-class: 'rating-trends';
             margin-top: 1rem;
             font-size: 2.5rem;
             font-weight: 500;
+            color: $default-black;
 
             &__positive {
-                color: #2E7D32;
+                color: $default-green;
             }
 
             &__negative {
-                color: #C62828;
+                color: $default-red;
             }
 
             &__hide {

--- a/src/assets/styles/_trend-display.scss
+++ b/src/assets/styles/_trend-display.scss
@@ -5,21 +5,17 @@ $block-class: 'trend-display';
 
 @at-root {
     .#{$block-class} {
+        @extend .rating-trends__panel; 
+        &--width-25 {
+            @extend .rating-trends__panel--width-25; 
+        }
 
-        &__panel {
-            @extend .rating-trends__panel; 
+        &--width-50 {
+            @extend .rating-trends__panel--width-50; 
+        }
 
-            &--width-25 {
-                @extend .rating-trends__panel--width-25; 
-            }
-    
-            &--width-50 {
-                @extend .rating-trends__panel--width-50; 
-            }
-    
-            &--hide {
-                display: none;
-            }
+        &--hide {
+            display: none;
         }
         
         &__h3-header {

--- a/src/assets/styles/_trend-display.scss
+++ b/src/assets/styles/_trend-display.scss
@@ -1,0 +1,48 @@
+@use 'rating-trends';
+
+$block-class: 'trend-display';
+@import 'colors';
+
+@at-root {
+    .#{$block-class} {
+
+        &__panel {
+            @extend .rating-trends__panel; 
+
+            &--width-25 {
+                @extend .rating-trends__panel--width-25; 
+            }
+    
+            &--width-50 {
+                @extend .rating-trends__panel--width-50; 
+            }
+    
+            &--hide {
+                display: none;
+            }
+        }
+        
+        &__h3-header {
+            @extend .rating-trends__h3-header; 
+        }
+
+        & &__percent-change {
+            margin-top: 1rem;
+            font-size: 2.5rem;
+            font-weight: 500;
+            color: $default-black;
+
+            &--positive {
+                color: $default-green;
+            }
+
+            &--negative {
+                color: $default-red;
+            }
+
+            &--hide {
+                display: none;
+            }
+        }
+    }
+}

--- a/src/assets/styles/colors.scss
+++ b/src/assets/styles/colors.scss
@@ -1,5 +1,7 @@
 $default-gray: #808080;
-$default-red: #cc0000;
+$default-red: #C62828;
+$default-black: #263238;
+$default-green: #2E7D32;
 
 $gray-main: #616161;
 $gray-light: #CFDFDC;

--- a/src/components/Summary/RatingTrends.js
+++ b/src/components/Summary/RatingTrends.js
@@ -12,15 +12,15 @@ import TrendDisplay from './TrendDisplay';
 const starsTip = 'Star rating subject to change depending on measures and other resources. For more information, please contact NCQA.';
 
 function RatingTrends({ activeMeasure, trends, info }) {
-  const mainTrend = { measure: '', percentChange: '' };
-  const biggestGain = { measure: '', percentChange: '' };
-  const biggestLoss = { measure: '', percentChange: '' };
+  const mainTrend = { measure: '', percentChange: undefined };
+  const biggestGain = { measure: '', percentChange: undefined };
+  const biggestLoss = { measure: '', percentChange: undefined };
   let sortedTrends = [];
   const measureTrend = trends
     .find((trend) => trend.measure === activeMeasure.measure);
 
   mainTrend.measure = info[activeMeasure.measure] !== undefined ? info[activeMeasure.measure].displayLabel : '';
-  mainTrend.percentChange = measureTrend === undefined ? '' : measureTrend.percentChange;
+  mainTrend.percentChange = measureTrend === undefined ? undefined : measureTrend.percentChange;
   if (activeMeasure.measure === 'composite') {
     sortedTrends = trends
       .filter((trend) => trend.measure !== 'composite')
@@ -57,14 +57,14 @@ const renderUI = (activeMeasure, mainTrend, renderOptions) => (
     <Box className="rating-trends__display-box">
       <Box className="rating-trends__panel-box">
         <Grid className={`rating-trends__panel 
-          ${renderOptions.displayAll ? 'rating-trends__panel__width-25' : 'rating-trends__panel__width-50'}`}
+          rating-trends__panel${renderOptions.displayAll ? '--width-25' : '--width-50'}`}
         >
           <Grid className="rating-trends__header-align">
             <Typography variant="h3" className="rating-trends__h3-header">
               Star Rating
             </Typography>
             <ToolTip title={starsTip}>
-              <HelpIcon className="rating-trends__help" fontSize="small" />
+              <HelpIcon className="rating-trends__help-icon" fontSize="small" />
             </ToolTip>
           </Grid>
           <Rating
@@ -115,7 +115,7 @@ RatingTrends.propTypes = {
   }),
   trends: PropTypes.arrayOf(
     PropTypes.shape({
-      measure: PropTypes.string,
+      measure: PropTypes.number,
     }),
   ),
 }

--- a/src/components/Summary/RatingTrends.js
+++ b/src/components/Summary/RatingTrends.js
@@ -7,6 +7,7 @@ import { Box } from '@mui/system';
 import {
   Button, Grid, Typography,
 } from '@mui/material';
+import TrendDisplay from './TrendDisplay';
 
 const starsTip = 'Star rating subject to change depending on measures and other resources. For more information, please contact NCQA.';
 
@@ -77,61 +78,18 @@ const renderUI = (activeMeasure, mainTrend, renderOptions) => (
             {activeMeasure.label && `(${activeMeasure.label})`}
           </Typography>
         </Grid>
-        <Grid className={`rating-trends__panel 
-          ${renderOptions.displayAll ? 'rating-trends__panel__width-25' : 'rating-trends__panel__width-50'}`}
-        >
-          <Typography variant="h3" className="rating-trends__h3-header">
-            { mainTrend.measure }
-            {' '}
-            % Compliance
-          </Typography>
-          <Typography className={`rating-trends__percent-change ${mainTrend.percentChange >= 0
-            ? 'rating-trends__percent-change__positive' : 'rating-trends__percent-change__negative'}`}
-          >
-            { mainTrend.percentChange }
-            %
-          </Typography>
-          <Typography>
-            (over the past week)
-          </Typography>
-        </Grid>
-        <Grid className={`rating-trends__panel rating-trends__panel__width-25 
-          ${renderOptions.displayAll ? '' : 'rating-trends__panel__hide'}`}
-        >
-          <Typography variant="h3" className="rating-trends__h3-header">
-            { renderOptions.biggestGain.measure }
-            {' '}
-            % Compliance
-          </Typography>
-          <Typography className={`rating-trends__percent-change ${renderOptions.biggestGain.percentChange >= 0
-            ? 'rating-trends__percent-change__positive' : 'rating-trends__percent-change__negative'}`}
-          >
-            { renderOptions.biggestGain.percentChange }
-            %
-          </Typography>
-
-          <Typography>
-            (over the past week)
-          </Typography>
-        </Grid>
-        <Grid className={`rating-trends__panel rating-trends__panel__width-25 
-          ${renderOptions.displayAll ? '' : 'rating-trends__panel__hide'}`}
-        >
-          <Typography variant="h3" className="rating-trends__h3-header">
-            { renderOptions.biggestLoss.measure }
-            {' '}
-            % Compliance
-          </Typography>
-          <Typography className={`rating-trends__percent-change ${renderOptions.biggestLoss.percentChange >= 0
-            ? 'rating-trends__percent-change__positive' : 'rating-trends__percent-change__negative'}`}
-          >
-            { renderOptions.biggestLoss.percentChange }
-            %
-          </Typography>
-          <Typography>
-            (over the past week)
-          </Typography>
-        </Grid>
+        <TrendDisplay
+          trend={mainTrend}
+          percentWidth={renderOptions.displayAll ? 25 : 50}
+        />
+        <TrendDisplay
+          trend={renderOptions.biggestGain}
+          percentWidth={renderOptions.displayAll ? 25 : 0}
+        />
+        <TrendDisplay
+          trend={renderOptions.biggestLoss}
+          percentWidth={renderOptions.displayAll ? 25 : 0}
+        />
       </Box>
       <Box className="rating-trends__button-panel">
         {

--- a/src/components/Summary/RatingTrends.js
+++ b/src/components/Summary/RatingTrends.js
@@ -115,7 +115,7 @@ RatingTrends.propTypes = {
   }),
   trends: PropTypes.arrayOf(
     PropTypes.shape({
-      measure: PropTypes.number,
+      measure: PropTypes.string,
     }),
   ),
 }

--- a/src/components/Summary/TrendDisplay.js
+++ b/src/components/Summary/TrendDisplay.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Grid, Typography,
+} from '@mui/material';
+
+function TrendDisplay({ trend, percentWidth }) {
+  let panelClass = 'rating-trends__panel__hide';
+  if (percentWidth === 25) {
+    panelClass = 'rating-trends__panel__width-25';
+  } else if (percentWidth === 50) {
+    panelClass = 'rating-trends__panel__width-50';
+  }
+
+  const header = `${trend.measure} % Compliance`;
+  let trendClass = '';
+  let trendValue = 'N/A';
+  if (trend.percentChange !== 'NA') {
+    if (trend.percentChange >= 0) {
+      trendClass = 'rating-trends__percent-change__positive';
+      trendValue = `+ ${trend.percentChange} %`
+    } else {
+      trendClass = 'rating-trends__percent-change__negative';
+      trendValue = `- ${Math.abs(trend.percentChange)} %`
+    }
+  }
+
+  return (
+    <Grid className={`rating-trends__panel ${panelClass}`}>
+      <Typography variant="h3" className="rating-trends__h3-header">
+        {header}
+      </Typography>
+      <Typography className={`rating-trends__percent-change ${trendClass}`}>
+        { trendValue }
+      </Typography>
+      <Typography>
+        (over the past week)
+      </Typography>
+    </Grid>
+  )
+}
+
+TrendDisplay.propTypes = {
+  trend: PropTypes.shape({
+    measure: PropTypes.string,
+    percentChange: PropTypes.number,
+  }),
+  percentWidth: PropTypes.number,
+}
+
+TrendDisplay.defaultProps = {
+  trend: {
+    measure: '',
+    percentChange: 0,
+  },
+  percentWidth: 0,
+}
+
+export default TrendDisplay;

--- a/src/components/Summary/TrendDisplay.js
+++ b/src/components/Summary/TrendDisplay.js
@@ -5,32 +5,31 @@ import {
 } from '@mui/material';
 
 function TrendDisplay({ trend, percentWidth }) {
-  let panelClass = 'rating-trends__panel__hide';
+  let panelClass = 'trend-display__panel--hide';
   if (percentWidth === 25) {
-    panelClass = 'rating-trends__panel__width-25';
+    panelClass = 'trend-display__panel--width-25';
   } else if (percentWidth === 50) {
-    panelClass = 'rating-trends__panel__width-50';
+    panelClass = 'trend-display__panel--width-50';
   }
 
-  const header = `${trend.measure} % Compliance`;
   let trendClass = '';
   let trendValue = 'N/A';
   if (trend.percentChange) {
     if (trend.percentChange >= 0) {
-      trendClass = 'rating-trends__percent-change__positive';
+      trendClass = 'trend-display__percent-change__positive';
       trendValue = `+ ${trend.percentChange} %`
     } else {
-      trendClass = 'rating-trends__percent-change__negative';
+      trendClass = 'trend-display__percent-change__negative';
       trendValue = `- ${Math.abs(trend.percentChange)} %`
     }
   }
 
   return (
-    <Grid className={`rating-trends__panel ${panelClass}`}>
-      <Typography variant="h3" className="rating-trends__h3-header">
-        {header}
+    <Grid className={`trend-display__panel ${panelClass}`}>
+      <Typography variant="h3" className="trend-display__h3-header">
+        {`${trend.measure} % Compliance`}
       </Typography>
-      <Typography className={`rating-trends__percent-change ${trendClass}`}>
+      <Typography className={`trend-display__percent-change ${trendClass}`}>
         { trendValue }
       </Typography>
       <Typography>

--- a/src/components/Summary/TrendDisplay.js
+++ b/src/components/Summary/TrendDisplay.js
@@ -5,27 +5,27 @@ import {
 } from '@mui/material';
 
 function TrendDisplay({ trend, percentWidth }) {
-  let panelClass = 'trend-display__panel--hide';
+  let panelClass = 'trend-display--hide';
   if (percentWidth === 25) {
-    panelClass = 'trend-display__panel--width-25';
+    panelClass = 'trend-display--width-25';
   } else if (percentWidth === 50) {
-    panelClass = 'trend-display__panel--width-50';
+    panelClass = 'trend-display--width-50';
   }
 
   let trendClass = '';
   let trendValue = 'N/A';
   if (trend.percentChange) {
     if (trend.percentChange >= 0) {
-      trendClass = 'trend-display__percent-change__positive';
-      trendValue = `+ ${trend.percentChange} %`
+      trendClass = 'trend-display__percent-change--positive';
+      trendValue = `+${trend.percentChange} %`
     } else {
-      trendClass = 'trend-display__percent-change__negative';
-      trendValue = `- ${Math.abs(trend.percentChange)} %`
+      trendClass = 'trend-display__percent-change--negative';
+      trendValue = `-${Math.abs(trend.percentChange)} %`
     }
   }
 
   return (
-    <Grid className={`trend-display__panel ${panelClass}`}>
+    <Grid className={`trend-display ${panelClass}`}>
       <Typography variant="h3" className="trend-display__h3-header">
         {`${trend.measure} % Compliance`}
       </Typography>

--- a/src/components/Summary/TrendDisplay.js
+++ b/src/components/Summary/TrendDisplay.js
@@ -15,7 +15,7 @@ function TrendDisplay({ trend, percentWidth }) {
   const header = `${trend.measure} % Compliance`;
   let trendClass = '';
   let trendValue = 'N/A';
-  if (trend.percentChange !== 'NA') {
+  if (trend.percentChange) {
     if (trend.percentChange >= 0) {
       trendClass = 'rating-trends__percent-change__positive';
       trendValue = `+ ${trend.percentChange} %`
@@ -51,7 +51,6 @@ TrendDisplay.propTypes = {
 TrendDisplay.defaultProps = {
   trend: {
     measure: '',
-    percentChange: 0,
   },
   percentWidth: 0,
 }

--- a/src/layouts/Dashboard.js
+++ b/src/layouts/Dashboard.js
@@ -28,7 +28,6 @@ export default function Dashboard() {
   const { datastore } = useContext(DatastoreContext);
   const [filterDrawerOpen, toggleFilterDrawer] = useState(false);
   const [activeMeasure, setActiveMeasure] = useState({});
-  console.log(datastore);
 
   useEffect(() => {
     if (datastore.currentResults !== undefined) {

--- a/src/layouts/Dashboard.js
+++ b/src/layouts/Dashboard.js
@@ -28,6 +28,7 @@ export default function Dashboard() {
   const { datastore } = useContext(DatastoreContext);
   const [filterDrawerOpen, toggleFilterDrawer] = useState(false);
   const [activeMeasure, setActiveMeasure] = useState({});
+  console.log(datastore);
 
   useEffect(() => {
     if (datastore.currentResults !== undefined) {


### PR DESCRIPTION
Also refactored trend display to make it more clear how values are set

# Related Tickets

- [SAR-415](https://jira.amida-tech.com/browse/SAR-415)

# Other Repos' PR(s) Intended to Work With This PR

- [HeRA #23](https://github.com/amida-tech/saraswati-hedis-results-api/pull/23)

# How Things Worked (or Didn't) Before This PR

If HeRA would throw an error the call would fail and the dashboard would have nothing to display. There is a PR for HeRA that will have it return `NA` and a trend. But dashboard doesn't know how to handle that.

# How Things Work Now (And How to Test)

Now if HeRA sends `NA` as a result dashboard will know to display the text N/A so the users are clear there is no trend data currently.

To test run a `POST` request to `http://localhost:4000/api/v1/measures/calculate`. That'll calculate results for today, and since you most likely don't have any results 7 days ago you won't get valid trend data.
