### PR TITLE
Feature/sar 361 d3 chart page styling

### DIFF
--- a/src/assets/styles/App.scss
+++ b/src/assets/styles/App.scss
@@ -2,6 +2,7 @@
 @use 'chart-bar';
 @use 'd3-chart';
 @use 'd3-container';
+@use 'd3-indicator-by-line-chart';
 @use 'filter-drawer';
 @use 'filter-drawer-item';
 @use 'footer';

--- a/src/assets/styles/_d3-chart.scss
+++ b/src/assets/styles/_d3-chart.scss
@@ -18,23 +18,21 @@ $AXIS_LABEL_COLOR: #b0bec5;
     }
     &__x-axis {
       display: none;
-
     }
     &__y-axis {
-      color: white;
+      color: $YAXIS_LINE_COLOR;
     }
     &__y-axisColorDeselect {
-      color:white
+      color: white;
     }
-    &__stroke-Dasharray {
+    &__stroke-stroke-width-opacity {
       color: $YAXIS_LINE_COLOR;
-      // stroke-dasharray:15 5; 
+      // stroke-dasharray:15 5;
       stroke-width: 2;
-      stroke-opacity: .5;
-
+      stroke-opacity: 0.5;
     }
-    &__label{
-      fill:$AXIS_LABEL_COLOR;
+    &__label {
+      fill: $AXIS_LABEL_COLOR;
       font-size: 1.3rem;
       font-weight: bold;
       text-anchor: middle;
@@ -67,6 +65,5 @@ $AXIS_LABEL_COLOR: #b0bec5;
       fill: none;
       pointer-events: all;
     }
-  
   }
 }

--- a/src/assets/styles/_d3-chart.scss
+++ b/src/assets/styles/_d3-chart.scss
@@ -9,7 +9,7 @@ $AXIS_LABEL_COLOR: #b0bec5;
 
     &__line-chart {
       height: 650px;
-      width: 90vw;
+      width: 93vw;
       background-color: #fff;
     }
 

--- a/src/assets/styles/_d3-chart.scss
+++ b/src/assets/styles/_d3-chart.scss
@@ -11,7 +11,6 @@ $AXIS_LABEL_COLOR: #b0bec5;
       height: 500px;
       width: 90vw;
       background-color: #fff;
-      // transform: translate(30px, 50px);
     }
 
     &__line {
@@ -23,9 +22,13 @@ $AXIS_LABEL_COLOR: #b0bec5;
     &__y-axis {
       color: $YAXIS_LINE_COLOR;
     }
-    &__dates {
+    &__ratingY {
       color: $AXIS_LABEL_COLOR;
-
+      font-size: 1.125rem;
+      font-weight: bold;
+    }
+    &__datesX {
+      color: $AXIS_LABEL_COLOR;
       font-size: 1.125rem;
       font-weight: bold;
     }

--- a/src/assets/styles/_d3-chart.scss
+++ b/src/assets/styles/_d3-chart.scss
@@ -5,10 +5,10 @@ $AXIS_LABEL_COLOR: #b0bec5;
 
 @at-root {
   .#{$block-class} {
-    width: 80vw;
+    width: 90vw;
 
     &__line-chart {
-      height: 500px;
+      height: 650px;
       width: 90vw;
       background-color: #fff;
     }
@@ -18,9 +18,26 @@ $AXIS_LABEL_COLOR: #b0bec5;
     }
     &__x-axis {
       display: none;
+
     }
     &__y-axis {
+      color: white;
+    }
+    &__y-axisColorDeselect {
+      color:white
+    }
+    &__stroke-Dasharray {
       color: $YAXIS_LINE_COLOR;
+      // stroke-dasharray:15 5; 
+      stroke-width: 2;
+      stroke-opacity: .5;
+
+    }
+    &__label{
+      fill:$AXIS_LABEL_COLOR;
+      font-size: 1.3rem;
+      font-weight: bold;
+      text-anchor: middle;
     }
     &__ratingY {
       color: $AXIS_LABEL_COLOR;
@@ -50,5 +67,6 @@ $AXIS_LABEL_COLOR: #b0bec5;
       fill: none;
       pointer-events: all;
     }
+  
   }
 }

--- a/src/assets/styles/_d3-indicator-by-line-chart.scss
+++ b/src/assets/styles/_d3-indicator-by-line-chart.scss
@@ -50,18 +50,18 @@ $AXIS_LABEL_COLOR: #b0bec5;
       font-weight: bold;
     }
     &__tooltip {
-      // position: absolute;
-      // z-index: 10;
-      // visibility: hidden;
-      // background: grey;
-      // border: 1px solid black;
-      // color: white;
-      // padding: 5px 10px;
-      // font-size: 1rem;
-      // font-weight: bold;
-      // border-radius: 10px;
-      // visibility: hidden;
-      // white-space: pre-line;
+      position: absolute;
+      z-index: 10;
+      visibility: hidden;
+      background: grey;
+      border: 1px solid black;
+      color: white;
+      padding: 5px 10px;
+      font-size: 1rem;
+      font-weight: bold;
+      border-radius: 10px;
+      visibility: hidden;
+      white-space: pre-line;
     }
     &__overlay {
       // fill: none;

--- a/src/assets/styles/_d3-indicator-by-line-chart.scss
+++ b/src/assets/styles/_d3-indicator-by-line-chart.scss
@@ -1,0 +1,72 @@
+$block-class: 'd3-indicator-by-line-chart';
+// d3-indicator-by-line-chart
+$YAXIS_LINE_COLOR: #cfd8dc;
+$AXIS_LABEL_COLOR: #b0bec5;
+
+@at-root {
+  .#{$block-class} {
+    // width: 90vw;
+
+    &__line-chart {
+      height: 650px;
+      width: 92vw;
+      background-color: #fff;
+    }
+
+    &__line {
+      // color: green;
+    }
+    &__x-axis {
+      display: none;
+
+    }
+    &__y-axis {
+      color: $YAXIS_LINE_COLOR;
+    }
+    &__y-axisColorDeselect {
+      // color:white
+    }
+    &__stroke-stroke-width-opacity {
+      // color: $YAXIS_LINE_COLOR;
+      // stroke-dasharray:15 5; 
+      // stroke-width: 2;
+      // stroke-opacity: .5;
+
+    }
+    &__label{
+      fill:$AXIS_LABEL_COLOR;
+      font-size: 1.3rem;
+      font-weight: bold;
+      text-anchor: middle;
+    }
+    &__ratingY {
+      color: $AXIS_LABEL_COLOR;
+      font-size: 1.125rem;
+      font-weight: bold;
+    }
+    &__datesX {
+      color: $AXIS_LABEL_COLOR;
+      font-size: 1.125rem;
+      font-weight: bold;
+    }
+    &__tooltip {
+      // position: absolute;
+      // z-index: 10;
+      // visibility: hidden;
+      // background: grey;
+      // border: 1px solid black;
+      // color: white;
+      // padding: 5px 10px;
+      // font-size: 1rem;
+      // font-weight: bold;
+      // border-radius: 10px;
+      // visibility: hidden;
+      // white-space: pre-line;
+    }
+    &__overlay {
+      // fill: none;
+      // pointer-events: all;
+    }
+  
+  }
+}

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -130,7 +130,6 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       .select('body')
       .append('div')
       .attr('class', 'd3-chart__tooltip');
-
     const toolTipGenerator = (event) => {
       const avg30 = margin.left * 0.3;
       const tickWidth = Math.floor(width / tickCount + avg30);

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -2,10 +2,11 @@
 import { TickChange } from 'components/Utilites/TickChange';
 import * as d3 from 'd3';
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { colorMappingProps } from './D3Props';
 
 function D3Chart({ displayData, colorMapping, measureInfo }) {
+  const [viewByPercentage, setViewByPercentage] = useState(true)
   // Binder for react to apply changes to the svg
   const D3LineChart = useRef();
 
@@ -22,7 +23,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
     top: 50,
     right: 30,
     bottom: 75,
-    left: 40,
+    left: 45,
   };
   const box = document.querySelector('.MuiGrid-item');
   const widthBase = (window.innerWidth || document.body.clientWidth);
@@ -46,7 +47,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       .select(D3LineChart.current)
       .attr('class', 'd3-chart__line-chart')
       .append('g')
-      .attr('transform', `translate(${margin.left + 15},${margin.top})`);
+      .attr('transform', `translate(${margin.left + 30},${margin.top})`);
 
     // Generates labels and context for x axis
     const x = d3.scaleTime() // What data we're measuring
@@ -57,7 +58,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
     // X Axis labels and context
     svg
       .append('g')
-      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .attr('transform', `translate(0,${height - margin.bottom / 1.4})`)
       .attr('class', 'd3-chart__datesX')
       .call(
         d3.axisBottom(x).ticks(tickCount).tickFormat(d3.timeFormat('%b %d')),
@@ -103,23 +104,21 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
 
     svg.append('text')
       .attr('x', width / 2)
+      .attr('y', height + 20)
       .attr('class', 'd3-chart__label')
-      .attr('y', -30)
-      .attr('text-anchor', 'middle')
-      .attr('fint-size', '10px')
-      .attr('fill', 'black')
-      .text('demoData Graph (D3)');
+      .text('Year to Date');
 
     // Y axis label:
     svg
       .append('text')
-      .attr('text-anchor', 'middle')
       .attr('class', 'd3-chart__label')
       .attr('transform', 'rotate(-90)')
       .attr('y', -margin.left - 20)
       .attr('x', -margin.top - 160)
-      .text('Percent of Measure');
+      .text(`${viewByPercentage ? 'Percent' : 'Rating'}`);
 
+    // Change Ticks to Percent
+    if (viewByPercentage) { TickChange() }
     // Generates the actual line
     const line = d3
       .line()
@@ -138,12 +137,13 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       const avg30 = margin.left * 0.3;
       const tickWidth = Math.floor(width / tickCount + avg30);
       const index = Math.floor((event.offsetX - margin.left) / tickWidth);
-      const measureDisplay = measureInfo[
+      const MeasureValue = measureInfo[
         event.srcElement.__data__[index].measure
-      ].displayLabel;
+      ].displayLabel
+      const measureDisplay = MeasureValue === 'Composite' ? `${MeasureValue} Score` : `Measure: ${MeasureValue}`;
       const valueDisplay = `Value: ${
         Math.floor(event.srcElement.__data__[index].value * 100) / 100
-      }`;
+      }%`;
       const dateDisplay = TimeFormatter(event.srcElement.__data__[index].date);
       tooltip.text(`${measureDisplay} \n ${valueDisplay} \n ${dateDisplay}`);
       const { color } = colorMapping.find(
@@ -156,7 +156,6 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
         .style('top', `${event.pageY - 10}px`)
         .style('left', `${event.pageX + 10}px`);
     };
-    TickChange()
 
     // Iterates through an array variation.
     if (measureList.length > 0) {

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -27,7 +27,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
   };
   const box = document.querySelector('.MuiGrid-item');
   const widthBase = (window.innerWidth || document.body.clientWidth);
-  const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 200;
+  const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 220;
   const height = 500;
   const tickCount = displayData.length / measureList.length;
 
@@ -47,7 +47,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       .select(D3LineChart.current)
       .attr('class', 'd3-chart__line-chart')
       .append('g')
-      .attr('transform', `translate(${margin.left + 30},${margin.top})`);
+      .attr('transform', `translate(${margin.left + 50},${margin.top})`);
 
     // Generates labels and context for x axis
     const x = d3.scaleTime() // What data we're measuring
@@ -113,7 +113,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       .append('text')
       .attr('class', 'd3-chart__label')
       .attr('transform', 'rotate(-90)')
-      .attr('y', -margin.left - 20)
+      .attr('y', -margin.left - 25)
       .attr('x', -margin.top - 160)
       .text(`${viewByPercentage ? 'Percent' : 'Rating'}`);
 

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import { TickChange } from 'components/Utilites/TickChange';
 import * as d3 from 'd3';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
@@ -45,7 +46,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       .select(D3LineChart.current)
       .attr('class', 'd3-chart__line-chart')
       .append('g')
-      .attr('transform', `translate(${margin.left},${margin.top})`);
+      .attr('transform', `translate(${margin.left + 15},${margin.top})`);
 
     // Generates labels and context for x axis
     const x = d3.scaleTime() // What data we're measuring
@@ -57,7 +58,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
     svg
       .append('g')
       .attr('transform', `translate(0,${height - margin.bottom})`)
-      .attr('class', 'd3-chart__dates')
+      .attr('class', 'd3-chart__datesX')
       .call(
         d3.axisBottom(x).ticks(tickCount).tickFormat(d3.timeFormat('%b %d')),
       );
@@ -70,7 +71,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       .domain([0, 100])
       .range([height - margin.bottom, 0]);
 
-    svg.append('g').attr('class', 'd3-chart__dates').call(d3.axisLeft(y));
+    svg.append('g').attr('class', 'd3-chart__ratingY').call(d3.axisLeft(y));
 
     // Grid
     // gridlines in x axis function
@@ -98,13 +99,26 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
 
     d3.selectAll('.axis-grid line').style('stroke', 'lightgray');
 
-    // svg.append('text')
-    //   .attr('x', width / 2)
-    //   .attr('y', -30)
-    //   .attr('text-anchor', 'middle')
-    //   .attr('fint-size', '10px')
-    //   .attr('fill', 'black')
-    //   .text('demoData Graph (D3)');
+    // X axis label:
+
+    svg.append('text')
+      .attr('x', width / 2)
+      .attr('class', 'd3-chart__label')
+      .attr('y', -30)
+      .attr('text-anchor', 'middle')
+      .attr('fint-size', '10px')
+      .attr('fill', 'black')
+      .text('demoData Graph (D3)');
+
+    // Y axis label:
+    svg
+      .append('text')
+      .attr('text-anchor', 'middle')
+      .attr('class', 'd3-chart__label')
+      .attr('transform', 'rotate(-90)')
+      .attr('y', -margin.left - 20)
+      .attr('x', -margin.top - 160)
+      .text('Percent of Measure');
 
     // Generates the actual line
     const line = d3
@@ -142,6 +156,7 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
         .style('top', `${event.pageY - 10}px`)
         .style('left', `${event.pageX + 10}px`);
     };
+    TickChange()
 
     // Iterates through an array variation.
     if (measureList.length > 0) {
@@ -169,7 +184,6 @@ function D3Chart({ displayData, colorMapping, measureInfo }) {
       });
     }
   });
-
   return (
     <div className="d3-chart">
       <svg ref={D3LineChart} />

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -1,9 +1,5 @@
-import {
-  Grid, Paper, Tab, Tabs,
-} from '@mui/material';
-import React, {
-  createContext, useState, useEffect,
-} from 'react';
+import { Grid, Paper, Tab, Tabs } from '@mui/material';
+import React, { createContext, useState, useEffect } from 'react';
 import ChartBar from './ChartBar';
 import D3Chart from './D3Chart';
 import D3IndicatorByLineSelector from './D3IndicatorByLineSelector';
@@ -11,9 +7,13 @@ import D3IndicatorByLineChart from './D3IndicatorByLineChart';
 import TabPanel from '../Common/TabPanel';
 import FilterDrawer from '../FilterMenu/FilterDrawer';
 import MeasureResultsTable from '../MeasureResults/MeasureResultsTable';
-import { storeProps, dashboardStateProps, dashboardActionsProps } from './D3Props';
+import {
+  storeProps,
+  dashboardStateProps,
+  dashboardActionsProps,
+} from './D3Props';
 
-export const firstRenderContext = createContext(true)
+export const firstRenderContext = createContext(true);
 
 const colorArray = [
   '#003F5C',
@@ -26,7 +26,7 @@ const colorArray = [
   '#FFA600',
   '#9D02D7',
   '#0000FF',
-]
+];
 
 // If nothing set, select all.
 const defaultFilterState = {
@@ -34,10 +34,12 @@ const defaultFilterState = {
   stars: [],
   percentRange: [0, 100],
   sum: 0,
-}
+};
 
 function D3Container({ dashboardState, dashboardActions, store }) {
-  const [displayData, setDisplayData] = useState(store.results.map((result) => ({ ...result })));
+  const [displayData, setDisplayData] = useState(
+    store.results.map((result) => ({ ...result }))
+  );
   const [currentFilters, setCurrentFilters] = useState(defaultFilterState);
   const [tabValue, setTabValue] = useState(0);
   const [byLineMeasure, setByLineMeasure] = useState('');
@@ -51,10 +53,10 @@ function D3Container({ dashboardState, dashboardActions, store }) {
   const colorMap = measureList.map((item, index) => ({
     measure: item,
     color: index <= 10 ? colorArray[index] : colorArray[index % 10],
-  }))
+  }));
 
   useEffect(() => {
-    setDisplayData(store.results.map((result) => ({ ...result })))
+    setDisplayData(store.results.map((result) => ({ ...result })));
   }, [store]);
 
   useEffect(() => {
@@ -65,41 +67,48 @@ function D3Container({ dashboardState, dashboardActions, store }) {
 
   const handleDisplayDataUpdate = (measures, filters) => {
     let newDisplayData = store.results.map((result) => ({ ...result }));
-    newDisplayData = newDisplayData.filter((result) => measures.includes(result.measure));
+    newDisplayData = newDisplayData.filter((result) =>
+      measures.includes(result.measure)
+    );
     if (filters.domainsOfCare.length > 0) {
-      newDisplayData = newDisplayData.filter(
-        (result) => filters.domainsOfCare.includes(store.info[result.measure].domainOfCare),
+      newDisplayData = newDisplayData.filter((result) =>
+        filters.domainsOfCare.includes(store.info[result.measure].domainOfCare)
       );
     }
     if (filters.stars.length > 0) {
-      newDisplayData = newDisplayData.filter(
-        (result) => filters.stars.includes(Math.floor( // Floor for the .5 stars.
-          store.currentResults.find((current) => current.measure === result.measure).starRating,
-        )),
-      )
-    }
-    if (filters.percentRange[0] > 0 || filters.percentRange[1] < 100) {
-      newDisplayData = newDisplayData.filter(
-        (result) => {
-          const { value } = store.currentResults.find(
-            (current) => current.measure === result.measure,
-          );
-          return value >= filters.percentRange[0] && value <= filters.percentRange[1]
-        },
+      newDisplayData = newDisplayData.filter((result) =>
+        filters.stars.includes(
+          Math.floor(
+            // Floor for the .5 stars.
+            store.currentResults.find(
+              (current) => current.measure === result.measure
+            ).starRating
+          )
+        )
       );
     }
+    if (filters.percentRange[0] > 0 || filters.percentRange[1] < 100) {
+      newDisplayData = newDisplayData.filter((result) => {
+        const { value } = store.currentResults.find(
+          (current) => current.measure === result.measure
+        );
+        return (
+          value >= filters.percentRange[0] && value <= filters.percentRange[1]
+        );
+      });
+    }
     setDisplayData(newDisplayData);
-  }
+  };
 
   const handleTabChange = (event, index) => {
     setTabValue(index);
     setByLineMeasure(store.currentResults[0].measure);
     const filteredDisplayData = store.results.filter(
-      (item) => item.measure === store.currentResults[0].measure,
+      (item) => item.measure === store.currentResults[0].measure
     );
     setByLineDisplayData(filteredDisplayData);
     dashboardActions.setActiveMeasure(store.currentResults[0]);
-  }
+  };
 
   const handleMeasureChange = (event) => {
     let newSelectedMeasures;
@@ -107,7 +116,9 @@ function D3Container({ dashboardState, dashboardActions, store }) {
       newSelectedMeasures = selectedMeasures.concat(event.target.value);
       setSelectedMeasures(newSelectedMeasures);
     } else {
-      newSelectedMeasures = selectedMeasures.filter((result) => result !== event.target.value);
+      newSelectedMeasures = selectedMeasures.filter(
+        (result) => result !== event.target.value
+      );
       setSelectedMeasures(newSelectedMeasures);
     }
     handleDisplayDataUpdate(newSelectedMeasures, currentFilters);
@@ -116,17 +127,19 @@ function D3Container({ dashboardState, dashboardActions, store }) {
   const handleFilterChange = (filterOptions) => {
     setCurrentFilters(filterOptions);
     handleDisplayDataUpdate(selectedMeasures, filterOptions);
-  }
+  };
 
   const handleByLineChange = (event) => {
     setByLineMeasure(event.target.value);
     const filteredDisplayData = store.results.filter(
-      (item) => item.measure === event.target.value,
+      (item) => item.measure === event.target.value
     );
     setByLineDisplayData(filteredDisplayData);
-    dashboardActions.setActiveMeasure(store.currentResults.filter(
-      (item) => item.measure === event.target.value,
-    )[0]);
+    dashboardActions.setActiveMeasure(
+      store.currentResults.filter(
+        (item) => item.measure === event.target.value
+      )[0]
+    );
   };
 
   return (
@@ -148,10 +161,7 @@ function D3Container({ dashboardState, dashboardActions, store }) {
       <TabPanel value={tabValue} index={1}>
         <Paper>
           <Grid container>
-            <Grid
-              item
-              sx={{ width: '25%' }}
-            >
+            <Grid item sx={{ width: '25%' }}>
               <D3IndicatorByLineSelector
                 currentResults={store.currentResults}
                 byLineMeasure={byLineMeasure}
@@ -161,15 +171,14 @@ function D3Container({ dashboardState, dashboardActions, store }) {
           </Grid>
           <D3IndicatorByLineChart
             byLineDisplayData={byLineDisplayData}
+            colorMapping={colorMap}
+            measureInfo={store.info}
           />
         </Paper>
       </TabPanel>
       <TabPanel value={tabValue} index={0}>
         <Grid container justifyContent="space-evenly" direction="column">
-          <Grid
-            item
-            className="d3-container__chart"
-          >
+          <Grid item className="d3-container__chart">
             <ChartBar
               filterDrawerOpen={dashboardState.filterDrawerOpen}
               toggleFilterDrawer={dashboardActions.toggleFilterDrawer}
@@ -191,7 +200,7 @@ function D3Container({ dashboardState, dashboardActions, store }) {
         />
       </TabPanel>
     </div>
-  )
+  );
 }
 
 D3Container.propTypes = {
@@ -206,6 +215,6 @@ D3Container.defaultProps = {
     filterDrawerOpen: false,
   },
   dashboardActions: {},
-}
+};
 
 export default D3Container;

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -1,8 +1,14 @@
 import * as d3 from 'd3';
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { TickChange } from 'components/Utilites/TickChange';
+import { colorMappingProps } from './D3Props';
 
-function D3IndicatorByLineChart({ byLineDisplayData }) {
+function D3IndicatorByLineChart({
+  byLineDisplayData,
+  colorMapping,
+  measureInfo,
+}) {
   // Binder for react to apply changes to the svg
   const D3IndicatorLineChart = useRef();
 
@@ -14,11 +20,11 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
     top: 50,
     right: 30,
     bottom: 75,
-    left: 30,
+    left: 45,
   };
   const box = document.querySelector('.MuiGrid-item');
-  const widthBase = (window.innerWidth || document.body.clientWidth);
-  const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 200;
+  const widthBase = window.innerWidth || document.body.clientWidth;
+  const width = box === null ? widthBase * 0.8 : box.offsetWidth - 250;
   const height = 500;
   const tickCount = byLineDisplayData.length;
 
@@ -31,35 +37,40 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
       .select(D3IndicatorLineChart.current)
       .attr('width', width)
       .attr('height', height)
-      .style('background-color', 'white')
-      .style('color', 'black')
+      .attr('class', 'd3-indicator-by-line-chart__line-chart')
       .append('g')
-      .attr('transform', `translate(${margin.left},${margin.top})`);
+      .attr('transform', `translate(${margin.left + 65},${margin.top})`);
 
     // Generates labels and context for x axis
-    const x = d3.scaleTime()
-    // What data we're measuring
-      .domain(d3.extent(byLineDisplayData, (d) => parseDate(d.date.split('T')[0])))
-    // The 'width' of the data
+    const x = d3
+      .scaleTime()
+      // What data we're measuring
+      .domain(
+        d3.extent(byLineDisplayData, (d) => parseDate(d.date.split('T')[0]))
+      )
+      // The 'width' of the data
       .range([0, width]);
 
     // X Axis labels and context
     svg
       .append('g')
-      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .attr('transform', `translate(0,${height - margin.bottom / 1.4})`)
+      .attr('class', 'd3-indicator-by-line-chart__datesX')
       .call(
-        d3.axisBottom(x).ticks(tickCount).tickFormat(d3.timeFormat('%d-%b-%Y')),
+        d3.axisBottom(x).ticks(tickCount).tickFormat(d3.timeFormat('%b %d'))
       );
 
     // Generates Label and context for y axis
     d3.max(byLineDisplayData, (d) => d.value);
-
     const y = d3
       .scaleLinear()
-      .domain([0, 5])
+      .domain([0, 100])
       .range([height - margin.bottom, 0]);
 
-    svg.append('g').call(d3.axisLeft(y));
+    svg
+      .append('g')
+      .attr('class', 'd3-indicator-by-line-chart__ratingY')
+      .call(d3.axisLeft(y));
 
     // Grid
     // gridlines in x axis function
@@ -69,33 +80,85 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
 
     // gridlines in y axis function
     function makeYGridlines() {
-      return d3.axisLeft(y).ticks(10);
+      return d3.axisLeft(y).ticks(5);
     }
 
     // add the X gridlines
     svg
       .append('g')
-      .attr('class', 'axis-grid')
+      .attr('class', 'd3-indicator-by-line-chart__x-axis')
       .attr('transform', `translate(0,${height})`)
       .call(makeXGridlines().tickSize(-height).tickFormat(''));
 
     // add the Y gridlines
     svg
       .append('g')
-      .attr('class', 'axis-grid')
+      .attr('class', 'd3-indicator-by-line-chart__y-axis')
       .call(makeYGridlines().tickSize(-width).tickFormat(''));
 
     d3.selectAll('.axis-grid line').style('stroke', 'lightgray');
-
+    // Change Ticks to Percent
+    TickChange();
     // Generates the actual line
     const line = d3
       .line()
       // .curve(d3.curveCardinal)
       .x((d) => x(parseDate(d.date.split('T')[0])))
-      .y((d) => y(d.value / 20));
+      .y((d) => y(d.value));
+
+    // X axis label:
+    svg
+      .append('text')
+      .attr('x', width / 2)
+      .attr('y', height + 20)
+      .attr('class', 'd3-indicator-by-line-chart__label')
+      .text('Year to Date');
+
+    // Y axis label:
+    svg
+      .append('text')
+      .attr('class', 'd3-indicator-by-line-chart__label')
+      .attr('transform', 'rotate(-90)')
+      .attr('y', -margin.left - 25)
+      .attr('x', -margin.top - 160)
+      .text('Percent');
+    // Tool Tips
+    const tooltip = d3
+      .select('body')
+      .append('div')
+      .attr('class', 'd3-chart__tooltip');
+
+    const toolTipGenerator = (event) => {
+      // const avg30 = margin.left * 0.3;
+      // const tickWidth = Math.floor(width / tickCount + avg30);
+      // const index = Math.floor((event.offsetX - margin.left) / tickWidth);
+      console.log('byLineDisplayData', byLineDisplayData);
+      const MeasureValue =
+        measureInfo[event.srcElement.__data__[index].measure].displayLabel;
+      // const measureDisplay =
+      //   MeasureValue === 'Composite'
+      //     ? `${MeasureValue} Score`
+      //     : `Measure: ${MeasureValue}`;
+      // const valueDisplay = `Value: ${
+      //   Math.floor(event.srcElement.__data__[index].value * 100) / 100
+      // }%`;
+      // const dateDisplay = TimeFormatter(event.srcElement.__data__[index].date);
+      tooltip.text(`${measureDisplay} \n ${valueDisplay} \n ${dateDisplay}`);
+      // tooltip.text('Hello World');
+      // const { color } = colorMapping.find(
+      //   (mapping) => mapping.measure === event.target.__data__[0].measure
+      // );
+      return (
+        tooltip
+          .attr('data-html', 'true')
+          // .style('background-color', color)
+          .style('visibility', 'visible')
+          .style('top', `${event.pageY - 10}px`)
+          .style('left', `${event.pageX + 10}px`)
+      );
+    };
 
     // Iterates through an array variation.
-
     svg
       .append('path')
       .datum(byLineDisplayData)
@@ -106,10 +169,23 @@ function D3IndicatorByLineChart({ byLineDisplayData }) {
       .attr('d', line)
       .on('mouseover', (event) => {
         d3.select(event.currentTarget).attr('opacity', '1');
+        toolTipGenerator(event);
       })
+      .on('mousemove', (event) => toolTipGenerator(event))
       .on('mouseout', (event) => {
-        d3.select(event.currentTarget).attr('opacity', '.33');
+        d3.select(event.currentTarget).attr('opacity', '.50');
+        return tooltip.style('visibility', 'hidden');
       });
+    // Create line at end of chart to make it a complete box
+    svg
+      .append('line')
+      .attr('x1', width)
+      .attr('y1', 0)
+      .attr('x2', width)
+      .attr('y2', height - margin.bottom)
+      .style('stroke-width', 1)
+      .style('stroke', '#CFD8DC')
+      .style('fill', 'none');
   });
 
   return (
@@ -124,12 +200,18 @@ D3IndicatorByLineChart.propTypes = {
     PropTypes.shape({
       value: PropTypes.number,
       date: PropTypes.string,
-    }),
+    })
   ),
+  measureInfo: PropTypes.shape({
+    displayLabel: PropTypes.string,
+  }),
+  colorMapping: colorMappingProps,
 };
 
 D3IndicatorByLineChart.defaultProps = {
   byLineDisplayData: [],
+  measureInfo: {},
+  colorMapping: [],
 };
 
 export default D3IndicatorByLineChart;

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-underscore-dangle */
 import * as d3 from 'd3';
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { TickChange } from 'components/Utilites/TickChange';
+import { TickChange } from '../Utilites/TickChange';
 import { colorMappingProps } from './D3Props';
 
 function D3IndicatorByLineChart({
@@ -51,7 +52,7 @@ function D3IndicatorByLineChart({
       .scaleTime()
       // What data we're measuring
       .domain(
-        d3.extent(byLineDisplayData, (d) => parseDate(d.date.split('T')[0]))
+        d3.extent(byLineDisplayData, (d) => parseDate(d.date.split('T')[0])),
       )
       // The 'width' of the data
       .range([0, width]);
@@ -62,7 +63,7 @@ function D3IndicatorByLineChart({
       .attr('transform', `translate(0,${height - margin.bottom / 1.4})`)
       .attr('class', 'd3-indicator-by-line-chart__datesX')
       .call(
-        d3.axisBottom(x).ticks(tickCount).tickFormat(d3.timeFormat('%b %d'))
+        d3.axisBottom(x).ticks(tickCount).tickFormat(d3.timeFormat('%b %d')),
       );
 
     // Generates Label and context for y axis
@@ -137,19 +138,17 @@ function D3IndicatorByLineChart({
       const avg30 = margin.left * 0.3;
       const tickWidth = Math.floor(width / tickCount + avg30);
       const index = Math.floor((event.offsetX - margin.left) / tickWidth);
-      const MeasureValue =
-        measureInfo[event.srcElement.__data__[index].measure].displayLabel;
-      const measureDisplay =
-        MeasureValue === 'Composite'
-          ? `${MeasureValue} Score`
-          : `Measure: ${MeasureValue}`;
+      const MeasureValue = measureInfo[event.srcElement.__data__[index].measure].displayLabel;
+      const measureDisplay = MeasureValue === 'Composite'
+        ? `${MeasureValue} Score`
+        : `Measure: ${MeasureValue}`;
       const valueDisplay = `Value: ${
         Math.floor(event.srcElement.__data__[index].value * 100) / 100
       }%`;
       const dateDisplay = TimeFormatter(event.srcElement.__data__[index].date);
       tooltip.text(`${measureDisplay} \n ${valueDisplay} \n ${dateDisplay}`);
       const { color } = colorMapping.find(
-        (mapping) => mapping.measure === event.target.__data__[0].measure
+        (mapping) => mapping.measure === event.target.__data__[0].measure,
       );
       return tooltip
         .attr('data-html', 'true')
@@ -168,9 +167,8 @@ function D3IndicatorByLineChart({
       .attr(
         'stroke',
         colorMapping.find(
-          (mappingMeasure, i) =>
-            mappingMeasure.measure === byLineDisplayData[i].measure
-        ).color
+          (mappingMeasure, i) => mappingMeasure.measure === byLineDisplayData[i].measure,
+        ).color,
       )
       .attr('opacity', '.33')
       .attr('stroke-width', 2)
@@ -208,7 +206,7 @@ D3IndicatorByLineChart.propTypes = {
     PropTypes.shape({
       value: PropTypes.number,
       date: PropTypes.string,
-    })
+    }),
   ),
   measureInfo: PropTypes.shape({
     displayLabel: PropTypes.string,

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -27,7 +27,12 @@ function D3IndicatorByLineChart({
   const width = box === null ? widthBase * 0.8 : box.offsetWidth - 250;
   const height = 500;
   const tickCount = byLineDisplayData.length;
+  function TimeFormatter(dateToFormat) {
+    const dateSplit = dateToFormat.split('T')[0];
+    const dividedDate = dateSplit.split('-');
 
+    return `Date: ${dividedDate[1]}-${dividedDate[2]}-${dividedDate[0]}`;
+  }
   useEffect(() => {
     // Clear previous SVG
     d3.select(D3IndicatorLineChart.current).selectAll('*').remove();
@@ -129,33 +134,29 @@ function D3IndicatorByLineChart({
       .attr('class', 'd3-chart__tooltip');
 
     const toolTipGenerator = (event) => {
-      // const avg30 = margin.left * 0.3;
-      // const tickWidth = Math.floor(width / tickCount + avg30);
-      // const index = Math.floor((event.offsetX - margin.left) / tickWidth);
-      console.log('byLineDisplayData', byLineDisplayData);
+      const avg30 = margin.left * 0.3;
+      const tickWidth = Math.floor(width / tickCount + avg30);
+      const index = Math.floor((event.offsetX - margin.left) / tickWidth);
       const MeasureValue =
         measureInfo[event.srcElement.__data__[index].measure].displayLabel;
-      // const measureDisplay =
-      //   MeasureValue === 'Composite'
-      //     ? `${MeasureValue} Score`
-      //     : `Measure: ${MeasureValue}`;
-      // const valueDisplay = `Value: ${
-      //   Math.floor(event.srcElement.__data__[index].value * 100) / 100
-      // }%`;
-      // const dateDisplay = TimeFormatter(event.srcElement.__data__[index].date);
+      const measureDisplay =
+        MeasureValue === 'Composite'
+          ? `${MeasureValue} Score`
+          : `Measure: ${MeasureValue}`;
+      const valueDisplay = `Value: ${
+        Math.floor(event.srcElement.__data__[index].value * 100) / 100
+      }%`;
+      const dateDisplay = TimeFormatter(event.srcElement.__data__[index].date);
       tooltip.text(`${measureDisplay} \n ${valueDisplay} \n ${dateDisplay}`);
-      // tooltip.text('Hello World');
-      // const { color } = colorMapping.find(
-      //   (mapping) => mapping.measure === event.target.__data__[0].measure
-      // );
-      return (
-        tooltip
-          .attr('data-html', 'true')
-          // .style('background-color', color)
-          .style('visibility', 'visible')
-          .style('top', `${event.pageY - 10}px`)
-          .style('left', `${event.pageX + 10}px`)
+      const { color } = colorMapping.find(
+        (mapping) => mapping.measure === event.target.__data__[0].measure
       );
+      return tooltip
+        .attr('data-html', 'true')
+        .style('background-color', color)
+        .style('visibility', 'visible')
+        .style('top', `${event.pageY - 10}px`)
+        .style('left', `${event.pageX + 10}px`);
     };
 
     // Iterates through an array variation.
@@ -164,6 +165,13 @@ function D3IndicatorByLineChart({
       .datum(byLineDisplayData)
       .attr('fill', 'none')
       .attr('stroke', 'blue')
+      .attr(
+        'stroke',
+        colorMapping.find(
+          (mappingMeasure, i) =>
+            mappingMeasure.measure === byLineDisplayData[i].measure
+        ).color
+      )
       .attr('opacity', '.33')
       .attr('stroke-width', 2)
       .attr('d', line)

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -131,7 +131,7 @@ function D3IndicatorByLineChart({
     const tooltip = d3
       .select('body')
       .append('div')
-      .attr('class', 'd3-chart__tooltip');
+      .attr('class', 'd3-indicator-by-line-chart__tooltip');
 
     const toolTipGenerator = (event) => {
       const avg30 = margin.left * 0.3;

--- a/src/components/Utilites/TickChange.js
+++ b/src/components/Utilites/TickChange.js
@@ -1,0 +1,39 @@
+const TickChange = () => {
+  const ticksFound = document.querySelectorAll('.tick > text');
+  const YlineFound = document.querySelectorAll('.d3-chart__ratingY')[0].childNodes;
+  console.log('YlineFound', YlineFound);
+//   for (let i = 0; i < YlineFound.length; i++) {}
+
+  for (let i = 0; i < ticksFound.length; i++) {
+    const tickInnerHtml = ticksFound[i].innerHTML;
+
+    if (tickInnerHtml === '10') {
+      ticksFound[i].style.display = 'none';
+    } else if (tickInnerHtml === '30') {
+      ticksFound[i].style.display = 'none';
+    } else if (tickInnerHtml === '50') {
+      ticksFound[i].style.display = 'none';
+    } else if (tickInnerHtml === '70') {
+      ticksFound[i].style.display = 'none';
+    } else if (tickInnerHtml === '90') {
+      ticksFound[i].style.display = 'none';
+    }
+    ticksFound[0].innerHTML = `${ticksFound[0].innerHTML}`;
+
+    if (tickInnerHtml === '20') {
+      ticksFound[i].innerHTML = '20%';
+    } else if (tickInnerHtml === '40') {
+      ticksFound[i].innerHTML = '40%';
+    } else if (tickInnerHtml === '60') {
+      ticksFound[i].innerHTML = '60%';
+    } else if (tickInnerHtml === '80') {
+      ticksFound[i].innerHTML = '80%';
+    } else if (tickInnerHtml === '100') {
+      ticksFound[i].innerHTML = '100%';
+    } else if (tickInnerHtml === '0') {
+      ticksFound[i].innerHTML = '0%';
+    }
+  }
+}
+
+module.exports = { TickChange };

--- a/src/components/Utilites/TickChange.js
+++ b/src/components/Utilites/TickChange.js
@@ -2,14 +2,18 @@
 const TickChange = () => {
   const ticksFound = document.querySelectorAll('.tick > text');
   const tickLinesFound = document.querySelectorAll('.tick > line');
-  const tickLinesFoundX = document.querySelectorAll('.d3-chart__datesX > .tick > line');
+  const tickLinesFoundX = document.querySelectorAll(
+    '.d3-chart__datesX > .tick > line'
+  );
   const DomainsFound = document.querySelectorAll('.domain');
-
+  // D3 Chart
+  // D3 Chart
+  // D3 Chart
   for (let i = 0; i < tickLinesFoundX.length; i += 1) {
-    tickLinesFoundX[i].style.display = 'none'
+    tickLinesFoundX[i].style.display = 'none';
   }
   //   Making the X-AXIS DISAPPEAR
-  DomainsFound[0].style.display = 'none'
+  DomainsFound[0].style.display = 'none';
   // Changes Numbers to Percent
   for (let i = 0; i < ticksFound.length; i += 1) {
     const tickInnerHtml = ticksFound[i].innerHTML;
@@ -45,33 +49,42 @@ const TickChange = () => {
   // Removes Ticks on 10,30,50,70 and 90.
   for (let i = 0; i < tickLinesFound.length; i += 1) {
     if (tickLinesFound[i].__data__ === 0) {
-    //   tickLinesFound[i].style.color = 'white'
-      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+      // tickLinesFound[i].style.color = 'white'
+      tickLinesFound[i].classList.add('d3-chart__stroke-width-opacity');
     } else if (tickLinesFound[i].__data__ === 20) {
-      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+      tickLinesFound[i].classList.add('d3-chart__stroke-width-opacity');
     } else if (tickLinesFound[i].__data__ === 40) {
-      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+      tickLinesFound[i].classList.add('d3-chart__stroke-width-opacity');
     } else if (tickLinesFound[i].__data__ === 60) {
-      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+      tickLinesFound[i].classList.add('d3-chart__stroke-width-opacity');
     } else if (tickLinesFound[i].__data__ === 80) {
-      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+      tickLinesFound[i].classList.add('d3-chart__stroke-width-opacity');
     } else if (tickLinesFound[i].__data__ === 100) {
-      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+      tickLinesFound[i].classList.add('d3-chart__stroke-width-opacity');
     }
     // Removes Specific Ticks
     if (tickLinesFound[i].__data__ === 10) {
-      tickLinesFound[i].remove()
+      tickLinesFound[i].remove();
     } else if (tickLinesFound[i].__data__ === 30) {
-      tickLinesFound[i].remove()
+      tickLinesFound[i].remove();
     } else if (tickLinesFound[i].__data__ === 50) {
-      tickLinesFound[i].remove()
+      tickLinesFound[i].remove();
     } else if (tickLinesFound[i].__data__ === 70) {
-      tickLinesFound[i].remove()
+      tickLinesFound[i].remove();
     } else if (tickLinesFound[i].__data__ === 90) {
-      tickLinesFound[i].remove()
+      tickLinesFound[i].remove();
     }
   }
-//   console.log("tickLinesFound",tickLinesFound)
-}
+
+  // D3 Chart Indicator By Line Chart
+  // D3 Chart Indicator By Line Chart
+  // D3 Chart Indicator By Line Chart
+  const tickLinesFoundLineChartX = document.querySelectorAll(
+    '.d3-indicator-by-line-chart__datesX > .tick > line'
+  );
+  for (let i = 0; i < tickLinesFoundLineChartX.length; i += 1) {
+    tickLinesFoundLineChartX[i].style.display = 'none';
+  }
+};
 
 module.exports = { TickChange };

--- a/src/components/Utilites/TickChange.js
+++ b/src/components/Utilites/TickChange.js
@@ -1,12 +1,19 @@
+/* eslint-disable no-underscore-dangle */
 const TickChange = () => {
   const ticksFound = document.querySelectorAll('.tick > text');
-  const YlineFound = document.querySelectorAll('.d3-chart__ratingY')[0].childNodes;
-  console.log('YlineFound', YlineFound);
-//   for (let i = 0; i < YlineFound.length; i++) {}
+  const tickLinesFound = document.querySelectorAll('.tick > line');
+  const tickLinesFoundX = document.querySelectorAll('.d3-chart__datesX > .tick > line');
+  const DomainsFound = document.querySelectorAll('.domain');
 
+  for (let i = 0; i < tickLinesFoundX.length; i++) {
+    tickLinesFoundX[i].style.display = 'none'
+  }
+  //   Making the X-AXIS DISAPPEAR
+  DomainsFound[0].style.display = 'none'
+  // Changes Numbers to Percent
   for (let i = 0; i < ticksFound.length; i++) {
     const tickInnerHtml = ticksFound[i].innerHTML;
-
+    // Removes numbers of Y-axis on 10,30,50,70 and 90.
     if (tickInnerHtml === '10') {
       ticksFound[i].style.display = 'none';
     } else if (tickInnerHtml === '30') {
@@ -18,7 +25,8 @@ const TickChange = () => {
     } else if (tickInnerHtml === '90') {
       ticksFound[i].style.display = 'none';
     }
-    ticksFound[0].innerHTML = `${ticksFound[0].innerHTML}`;
+
+    // Changes numbers of Y-axis on 20,40,60,80 and 100 to %.
 
     if (tickInnerHtml === '20') {
       ticksFound[i].innerHTML = '20%';
@@ -34,6 +42,36 @@ const TickChange = () => {
       ticksFound[i].innerHTML = '0%';
     }
   }
+  // Removes Ticks on 10,30,50,70 and 90.
+  for (let i = 0; i < tickLinesFound.length; i++) {
+    if (tickLinesFound[i].__data__ === 0) {
+    //   tickLinesFound[i].style.color = 'white'
+      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+    } else if (tickLinesFound[i].__data__ === 20) {
+      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+    } else if (tickLinesFound[i].__data__ === 40) {
+      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+    } else if (tickLinesFound[i].__data__ === 60) {
+      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+    } else if (tickLinesFound[i].__data__ === 80) {
+      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+    } else if (tickLinesFound[i].__data__ === 100) {
+      tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')
+    }
+    // Removes Specific Ticks
+    if (tickLinesFound[i].__data__ === 10) {
+      tickLinesFound[i].remove()
+    } else if (tickLinesFound[i].__data__ === 30) {
+      tickLinesFound[i].remove()
+    } else if (tickLinesFound[i].__data__ === 50) {
+      tickLinesFound[i].remove()
+    } else if (tickLinesFound[i].__data__ === 70) {
+      tickLinesFound[i].remove()
+    } else if (tickLinesFound[i].__data__ === 90) {
+      tickLinesFound[i].remove()
+    }
+  }
+//   console.log("tickLinesFound",tickLinesFound)
 }
 
 module.exports = { TickChange };

--- a/src/components/Utilites/TickChange.js
+++ b/src/components/Utilites/TickChange.js
@@ -5,13 +5,13 @@ const TickChange = () => {
   const tickLinesFoundX = document.querySelectorAll('.d3-chart__datesX > .tick > line');
   const DomainsFound = document.querySelectorAll('.domain');
 
-  for (let i = 0; i < tickLinesFoundX.length; i++) {
+  for (let i = 0; i < tickLinesFoundX.length; i += 1) {
     tickLinesFoundX[i].style.display = 'none'
   }
   //   Making the X-AXIS DISAPPEAR
   DomainsFound[0].style.display = 'none'
   // Changes Numbers to Percent
-  for (let i = 0; i < ticksFound.length; i++) {
+  for (let i = 0; i < ticksFound.length; i += 1) {
     const tickInnerHtml = ticksFound[i].innerHTML;
     // Removes numbers of Y-axis on 10,30,50,70 and 90.
     if (tickInnerHtml === '10') {
@@ -43,7 +43,7 @@ const TickChange = () => {
     }
   }
   // Removes Ticks on 10,30,50,70 and 90.
-  for (let i = 0; i < tickLinesFound.length; i++) {
+  for (let i = 0; i < tickLinesFound.length; i += 1) {
     if (tickLinesFound[i].__data__ === 0) {
     //   tickLinesFound[i].style.color = 'white'
       tickLinesFound[i].classList.add('d3-chart__stroke-Dasharray')


### PR DESCRIPTION
# Related Tickets

- [SAR-361](https://jira.amida-tech.com/browse/SAR-361)

# Other Repos' PR(s) Intended to Work With This PR

None

# How Things Worked (or Didn't) Before This PR
- Chart displayed ticks for every Number and Date.
- Chart displayed lines for every Number and Date.
- Date on x-axis was attached to chart.
- No labels on X and Y axis.
- Measure by line chart x axis was by measure star rating.
- X-axis values did not contain Percent.

# How Things Work Now (And How to Test)
- More Spacing on Chart Axis'
- ticks and lines only on y-axis at "0, 20, 40, 60, 80, 100", all other lines and ticks removed using DOM manipulation.
- Measure by line Styled the same as New D3-chart.
- Measure by line chart x axis was by rating out of 100.
- X-axis values contain Percents.
# Readiness

1. [x] This PR passes all automated tests.
2. [x] This PR has no linting errors.
3. [x] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
