### PR TITLE
[SAR-426] - Axis labels fix

### DIFF
--- a/src/assets/styles/_d3-chart.scss
+++ b/src/assets/styles/_d3-chart.scss
@@ -7,7 +7,7 @@ $block-class: 'd3-chart';
     width: 90vw;
 
     &__line-chart {
-      height: 650px;
+      height: 37.5rem;
       width: 93vw;
       background-color: #fff;
     }
@@ -40,7 +40,7 @@ $block-class: 'd3-chart';
 
     &__dates-x {
       color: $axis-label-color;
-      font-size: 1rem;
+      font-size: 0.875rem;
       font-weight: bold;
     }
 

--- a/src/assets/styles/_footer.scss
+++ b/src/assets/styles/_footer.scss
@@ -22,8 +22,7 @@ $block-class: 'footer';
       &__top-border {
         margin-bottom: 1rem;
         --border-opacity: 1;
-        border-color: #e2e8f0;
-        border-color: rgba(226, 232, 240, var(--border-opacity));
+        border-color: $blue-grey-darken-4;
       }
 
       &__flex-box {

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -135,9 +135,14 @@ function D3Chart({
       .append('div')
       .attr('class', 'd3-chart__tooltip');
     const toolTipGenerator = (event) => {
-      const avg30 = margin.left * 0.3;
-      const tickWidth = Math.floor(width / tickCount + avg30);
-      const index = Math.floor((event.offsetX - margin.left) / tickWidth);
+      const tickWidth = (width / (dataCount - 1));
+      let index = Math.floor((event.offsetX - 84) / (tickWidth));
+      if (index < 0) {
+        index = 0;
+      }
+      if (index >= dataCount) {
+        index = dataCount - 1;
+      }
       const MeasureValue = measureInfo[
         event.srcElement.__data__[index].measure
       ].displayLabel

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -26,9 +26,8 @@ function D3Chart({
     bottom: 75,
     left: 45,
   };
-  const box = document.querySelector('.MuiGrid-item');
-  const widthBase = (graphWidth || document.body.clientWidth);
-  const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 220;
+
+  const width = graphWidth - 220;
   const height = 500;
   const maxTickCount = width / 100;
   const dataCount = displayData.length / measureList.length
@@ -61,7 +60,7 @@ function D3Chart({
     // X Axis labels and context
     svg
       .append('g')
-      .attr('transform', `translate(0,${height - margin.bottom / 1.4})`)
+      .attr('transform', `translate(0,${height - (margin.bottom / 1.2)})`)
       .attr('class', 'd3-chart__dates-x')
       .call(
         d3.axisBottom(x).ticks(tickCount).tickFormat(d3.timeFormat('%b %d')),
@@ -107,7 +106,7 @@ function D3Chart({
 
     svg.append('text')
       .attr('x', width / 2)
-      .attr('y', height + 20)
+      .attr('y', height)
       .attr('class', 'd3-chart__label')
       .text('Year to Date');
     // Y axis label:

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -30,7 +30,9 @@ function D3Chart({
   const widthBase = (graphWidth || document.body.clientWidth);
   const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 220;
   const height = 500;
-  const tickCount = displayData.length / measureList.length;
+  const maxTickCount = width / 100;
+  const dataCount = displayData.length / measureList.length
+  const tickCount = dataCount > maxTickCount ? maxTickCount : dataCount;
 
   function TimeFormatter(dateToFormat) {
     const dateSplit = dateToFormat.split('T')[0];

--- a/src/components/ChartContainer/D3Chart.js
+++ b/src/components/ChartContainer/D3Chart.js
@@ -135,13 +135,8 @@ function D3Chart({
       .attr('class', 'd3-chart__tooltip');
     const toolTipGenerator = (event) => {
       const tickWidth = (width / (dataCount - 1));
-      let index = Math.floor((event.offsetX - 84) / (tickWidth));
-      if (index < 0) {
-        index = 0;
-      }
-      if (index >= dataCount) {
-        index = dataCount - 1;
-      }
+      const index = Math.floor((event.offsetX - 84) / (tickWidth));
+
       const MeasureValue = measureInfo[
         event.srcElement.__data__[index].measure
       ].displayLabel

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -202,23 +202,21 @@ function D3Container({ dashboardState, dashboardActions, store }) {
         <Tab label="Measure by Line" />
       </Tabs>
       <TabPanel value={tabValue} index={1}>
-        <Paper>
-          <Grid container>
-            <Grid item sx={{ width: '25%' }}>
-              <D3IndicatorByLineSelector
-                currentResults={store.currentResults}
-                byLineMeasure={byLineMeasure}
-                handleByLineChange={handleByLineChange}
-              />
-            </Grid>
+        <Grid container>
+          <Grid item sx={{ width: '25%' }}>
+            <D3IndicatorByLineSelector
+              currentResults={store.currentResults}
+              byLineMeasure={byLineMeasure}
+              handleByLineChange={handleByLineChange}
+            />
           </Grid>
-          <D3IndicatorByLineChart
-            byLineDisplayData={byLineDisplayData}
-            graphWidth={graphWidth}
-            colorMapping={colorMap}
-            measureInfo={store.info}
-          />
-        </Paper>
+        </Grid>
+        <D3IndicatorByLineChart
+          byLineDisplayData={byLineDisplayData}
+          graphWidth={graphWidth}
+          colorMapping={colorMap}
+          measureInfo={store.info}
+        />
       </TabPanel>
       <TabPanel value={tabValue} index={0}>
         <Grid container justifyContent="space-evenly" direction="column">

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -1,5 +1,5 @@
 import {
-  Grid, Paper, Tab, Tabs,
+  Grid, Tab, Tabs,
 } from '@mui/material';
 import React, {
   createContext, useState, useEffect,

--- a/src/components/ChartContainer/D3IndicatorByLineChart.js
+++ b/src/components/ChartContainer/D3IndicatorByLineChart.js
@@ -24,11 +24,12 @@ function D3IndicatorByLineChart({
     bottom: 75,
     left: 45,
   };
-  const box = document.querySelector('.MuiGrid-item');
-  const widthBase = (graphWidth || document.body.clientWidth);
-  const width = box === null ? (widthBase * 0.8) : box.offsetWidth - 220;
+
+  const width = graphWidth - 220;
   const height = 500;
-  const tickCount = byLineDisplayData.length;
+  const maxTickCount = width / 100;
+  const tickCount = byLineDisplayData.length > maxTickCount
+    ? maxTickCount : byLineDisplayData.length;
   function TimeFormatter(dateToFormat) {
     const dateSplit = dateToFormat.split('T')[0];
     const dividedDate = dateSplit.split('-');
@@ -136,9 +137,9 @@ function D3IndicatorByLineChart({
       .attr('class', 'd3-indicator-by-line-chart__tooltip');
 
     const toolTipGenerator = (event) => {
-      const avg30 = margin.left * 0.3;
-      const tickWidth = Math.floor(width / tickCount + avg30);
-      const index = Math.floor((event.offsetX - margin.left) / tickWidth);
+      const tickWidth = (width / (byLineDisplayData.length - 1));
+      const index = Math.floor((event.offsetX - 94) / (tickWidth));
+
       const MeasureValue = measureInfo[event.srcElement.__data__[index].measure].displayLabel;
       const measureDisplay = MeasureValue === 'Composite'
         ? `${MeasureValue} Score`

--- a/src/layouts/Dashboard.js
+++ b/src/layouts/Dashboard.js
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { ThemeProvider } from '@emotion/react';
-import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
@@ -14,14 +13,6 @@ import theme from '../assets/styles/AppTheme';
 import DashboardNavbar from '../components/Navbars/DashboardNavbar';
 import Banner from '../components/Summary/Banner';
 import RatingTrends from '../components/Summary/RatingTrends';
-
-const Item = styled(Paper)(() => ({
-  ...theme.typography.body2,
-  padding: theme.spacing(1),
-  textAlign: 'center',
-  color: theme.palette.text.secondary,
-  borderRadius: theme.shape.borderRadius.xl,
-}));
 
 export default function Dashboard() {
   const { datastore } = useContext(DatastoreContext);
@@ -61,13 +52,11 @@ export default function Dashboard() {
                 />
               </Grid>
               <Grid item xs={12}>
-                <Item>
-                  <D3Container
-                    store={datastore}
-                    dashboardState={dashboardState}
-                    dashboardActions={dashboardActions}
-                  />
-                </Item>
+                <D3Container
+                  store={datastore}
+                  dashboardState={dashboardState}
+                  dashboardActions={dashboardActions}
+                />
               </Grid>
             </Grid>
           </Box>


### PR DESCRIPTION
# Related Tickets

- [SAR-426](https://jira.amida-tech.com/browse/SAR-426)

# How Things Worked (or Didn't) Before This PR

If too many days worth of data were present on the chart all the days would smoosh together being unreadable.

# How Things Work Now (And How to Test)

Now there is a tick count limit based on the chart width. D3 is extra smart with it dynamically adjusting which ticks display based on the width. It could be

- Every day
- Every other day
- Every week (only showing Sundays)
- Every month (only showing the first of the month)

Also because I changed the tick count the tooltips stopped working. That is until I fixed them and adjusted the calculations to be even more accurate than before.

There were also other small updates to accommodate the smaller x-axis labels, adjusting chart resizing to work on smaller window sizes, and generally bring the chart closer to the Miro board standard.
