### PR TITLE
SAR-394 N/A for star ratings

### DIFF
--- a/src/assets/styles/_rating-trends.scss
+++ b/src/assets/styles/_rating-trends.scss
@@ -70,19 +70,15 @@ $block-class: 'rating-trends';
         }
         
         & &__star-rating {
-            margin-top:1.5rem;
+            margin: 1.5rem 0 0.75rem;
             font-size: 2.5rem;
         } // Because there are multiple spans beneath this, be specific.
 
-        & &__star-rating-label {
-            margin-top: 0.4rem;
-        }
-
         & &__not-available {
-            text-align: center;
-            font-weight: 600;
+            margin-top: 1rem;
             font-size: 2.5rem;
-            height: 2.875rem;
+            font-weight: 500;
+            color: $blue-grey-darken-4;
         }
 
         &__button-panel {

--- a/src/assets/styles/_rating-trends.scss
+++ b/src/assets/styles/_rating-trends.scss
@@ -78,6 +78,13 @@ $block-class: 'rating-trends';
             margin-top: 0.4rem;
         }
 
+        & &__not-available {
+            text-align: center;
+            font-weight: 600;
+            font-size: 2.5rem;
+            height: 2.875rem;
+        }
+
         &__button-panel {
             display: flex;
             justify-content: flex-end;

--- a/src/components/Summary/RatingTrends.js
+++ b/src/components/Summary/RatingTrends.js
@@ -12,6 +12,17 @@ import Info from './Info';
 const ratingTrendsTip = 'Rating and Trends displays the current projected star rating as well as highlighting large changes in tracked measures.'
 const starsTip = 'Star rating subject to change depending on measures and other resources. For more information, please contact NCQA.';
 
+function showStars(activeMeasure) {
+  let returnBool = false;
+
+  // Additional stars rules can be added here
+  if (activeMeasure.denominator > 30 && activeMeasure.starRating >= 0) {
+    returnBool = true;
+  }
+
+  return returnBool;
+}
+
 function RatingTrends({ activeMeasure, trends, info }) {
   const mainTrend = { measure: '', percentChange: undefined };
   const biggestGain = { measure: '', percentChange: undefined };
@@ -51,20 +62,6 @@ function RatingTrends({ activeMeasure, trends, info }) {
   });
 }
 
-const returnStars = (activeMeasure) => {
-  let returnBool = false;
-
-  // Additional stars rules can be added here
-  if (activeMeasure.starRating > 0) {
-    returnBool = true;
-  }
-  if (activeMeasure.denominator > 30) {
-    returnBool = true;
-  }
-
-  return returnBool;
-}
-
 const renderUI = (activeMeasure, mainTrend, renderOptions) => (
   <Box className="rating-trends">
     <Box className="rating-trends__main-header-align">
@@ -86,7 +83,7 @@ const renderUI = (activeMeasure, mainTrend, renderOptions) => (
               <HelpIcon className="rating-trends__help-icon" fontSize="small" />
             </ToolTip>
           </Grid>
-          {returnStars ? (
+          {showStars(activeMeasure) ? (
             <Rating
               className="rating-trends__star-rating"
               name="read-only"

--- a/src/components/Summary/RatingTrends.js
+++ b/src/components/Summary/RatingTrends.js
@@ -17,6 +17,7 @@ function RatingTrends({ activeMeasure, trends, info }) {
   const biggestGain = { measure: '', percentChange: undefined };
   const biggestLoss = { measure: '', percentChange: undefined };
   let sortedTrends = [];
+
   const measureTrend = trends
     .find((trend) => trend.measure === activeMeasure.measure);
 
@@ -50,6 +51,17 @@ function RatingTrends({ activeMeasure, trends, info }) {
   });
 }
 
+const returnStars = (activeMeasure) => {
+  let returnBool = false;
+
+  // Additional stars rules can be added here
+  if (activeMeasure.starRating > 0) {
+    returnBool = true;
+  }
+
+  return returnBool;
+}
+
 const renderUI = (activeMeasure, mainTrend, renderOptions) => (
   <Box className="rating-trends">
     <Box className="rating-trends__main-header-align">
@@ -71,13 +83,20 @@ const renderUI = (activeMeasure, mainTrend, renderOptions) => (
               <HelpIcon className="rating-trends__help-icon" fontSize="small" />
             </ToolTip>
           </Grid>
-          <Rating
-            className="rating-trends__star-rating"
-            name="read-only"
-            value={activeMeasure.starRating || 0}
-            precision={0.5}
-            readOnly
-          />
+          {returnStars ? (
+            <Rating
+              className="rating-trends__star-rating"
+              name="read-only"
+              value={activeMeasure.starRating || 0}
+              precision={0.5}
+              readOnly
+            />
+          )
+            : (
+              <Typography className="rating-trends__not-available">
+                N/A
+              </Typography>
+            )}
           <Typography className="rating-trends__star-rating-label">
             {activeMeasure.label && `(${activeMeasure.label})`}
           </Typography>
@@ -98,13 +117,13 @@ const renderUI = (activeMeasure, mainTrend, renderOptions) => (
       <Box className="rating-trends__button-panel">
         {
           process.env.REACT_APP_MVP_SETTING === 'false'
-        && (
-        <Button
-          className="rating-trends__view-rating-details-button"
-        >
-          View Rating Details
-        </Button>
-        )
+          && (
+            <Button
+              className="rating-trends__view-rating-details-button"
+            >
+              View Rating Details
+            </Button>
+          )
         }
       </Box>
     </Box>

--- a/src/components/Summary/RatingTrends.js
+++ b/src/components/Summary/RatingTrends.js
@@ -58,6 +58,9 @@ const returnStars = (activeMeasure) => {
   if (activeMeasure.starRating > 0) {
     returnBool = true;
   }
+  if (activeMeasure.denominator > 30) {
+    returnBool = true;
+  }
 
   return returnBool;
 }


### PR DESCRIPTION
# Related Tickets

- [SAR-394](https://amida.atlassian.net/browse/SAR-394)

# How Things Worked (or Didn't) Before This PR

Star ratings with an invalid total would display an empty star array. Additionally, any measure with a denominator of <30 will also show NA.

# How Things Work Now (And How to Test)

Now it displays `N/A`.

There is no method I've found with the development data to get the N/A to display. I eddited the develop data to get the results I wanted.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
