### PR TITLE
Bugfix/Node wrong version in jenkinsfile.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
   - name: node
-    image: node:13.10.1-alpine3.11
+    image: node:16.14.2-alpine3.15
     command:
     - cat
     tty: true


### PR DESCRIPTION
# How Things Worked (or Didn't) Before This PR

We were using the wrong node version for Jenkins support.

# How Things Work Now (And How to Test)

Updated the node image to one that works.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
