### PR TITLE
Bugfix/Node version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# FROM node:13.10.1-alpine3.11
+# FROM  node:16.14.2-alpine3.15
 
 # WORKDIR /app
 
@@ -10,7 +10,7 @@
 # CMD [ "yarn", "start" ]
 
 # Builder image
-FROM node:13.10.1-alpine3.11 as builder
+FROM node:16.14.2-alpine3.15 as builder
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN yarn build
 
 
 # Production Installer image
-FROM node:13.10.1-alpine3.11
+FROM node:16.14.2-alpine3.15
 
 WORKDIR /app
 


### PR DESCRIPTION
# How Things Worked (or Didn't) Before This PR

Dockerfile node version is wrong

# How Things Work Now (And How to Test)

Now it isn't. Updated to 16.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
