### PR TITLE
Bugfix/problems in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ spec:
         }
         stage('Build Production with Kaniko') {
             when { 
-                expression {env.GIT_BRANCH == 'master'} 
+                expression {env.GIT_BRANCH == 'origin/master'} 
             }
             steps {
                 container(name: 'kaniko', shell: '/busybox/sh') {
@@ -71,7 +71,7 @@ spec:
         }
         stage('Build Develop with Kaniko') {
             when { 
-                expression {env.GIT_BRANCH != 'master'} 
+                expression {env.GIT_BRANCH == 'origin/develop'} 
             }
             steps {
                 container(name: 'kaniko', shell: '/busybox/sh') {


### PR DESCRIPTION
# How Things Worked (or Didn't) Before This PR
The pointers for the respective git branches in the jenkinsfile were pointed to things that don't exist, and uptaking all failures to develop.

# How Things Work Now (And How to Test)

It now points directly at the relevant branches.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
