### PR TITLE
Bugfix - Fixing configuration so we can build in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /app
 
 # Copy only necessary files to install prod deps
 COPY --from=builder /app/ /app/
-RUN yarn install --production --frozen-lockfile && yarn cache clean
+RUN yarn install --frozen-lockfile && yarn cache clean
 # Up til this point should get cached and only re-run if dependencies change
 
 USER 50000:50000


### PR DESCRIPTION
# How Things Worked (or Didn't) Before This PR
The dashboard won't build in dockerhub due to a problem with a dependency on airb&b config in eslint.

# How Things Work Now (And How to Test)
There's no differentiation between production develop builds. 

However, this was actually already true, because we are storing the entire source instead of storing just the webpack in the docker image. This will need to be corrected in the future.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
