### PR TITLE
Feature/sar 418 time range options

### DIFF
--- a/src/assets/styles/AppTheme.js
+++ b/src/assets/styles/AppTheme.js
@@ -66,6 +66,7 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           borderRadius: '5px',
+          // color: '#808080',
         },
       },
     },

--- a/src/assets/styles/_chart-bar.scss
+++ b/src/assets/styles/_chart-bar.scss
@@ -9,6 +9,14 @@ $block-class: 'chart-bar';
       justify-content: left;
     }
 
+    &__radio-panel {
+      padding: 0 1rem;
+    }
+
+    &__radio-label {
+      color: $default-black;
+    }
+
     &__badge > span {
       color: #FFFFFF;
       background-color: $default-red;

--- a/src/assets/styles/_chart-bar.scss
+++ b/src/assets/styles/_chart-bar.scss
@@ -4,7 +4,6 @@ $block-class: 'chart-bar';
 
 @at-root {
   .#{$block-class} {
-
     & &__filter-button {
       width: 7rem;
       justify-content: left;
@@ -16,21 +15,37 @@ $block-class: 'chart-bar';
       transform: scale(1) translate(-50%, 30%);
       box-shadow: 0 0 0 2px $default-gray;
     }
+
+    &__date-panel {
+      display: flex;
+      align-items: baseline;
+      padding: 0 0.625rem;
+    }
+
+    &__date-text {
+      .MuiInputBase-input {
+        color: $default-black;
+      }
+    }
+
+    &__between-text {
+      margin: 0 1rem;
+      color: $default-black;
+    }
+
+    &__date-range-picker {
+      .MuiDateRangePickerDay-day {
+        color: $default-black;
+      }
+
+      .MuiTypography-subtitle1 {
+        color: $default-black;
+      }
+
+      .MuiPickersDay-today {
+        color: $blue-main;
+      }
+    }
   }
 }
 
-.css-1rp7wri-MuiButtonBase-root-MuiPickersDay-root-MuiDateRangePickerDay-day {
-  color: black !important;
-}
-
-.css-20qdlw-MuiButtonBase-root-MuiPickersDay-root-MuiDateRangePickerDay-day {
-  color: blue !important;
-}
-
-.css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input {
-  color: black !important;
-}
-
-.css-10wpov9-MuiTypography-root {
-  color: black !important;
-}

--- a/src/components/ChartContainer/ChartBar.js
+++ b/src/components/ChartContainer/ChartBar.js
@@ -74,8 +74,8 @@ function ChartBar({
   }
 
   return (
-    <Box>
-      <Grid container className="chart-bar" direction="row" justifyContent="flex-end" spacing={0.1}>
+    <Box className="chart-bar">
+      <Grid container direction="row" justifyContent="flex-end" spacing={0.1}>
         <Grid item sx={buttonStyling}>
           <Button
             key="d3-YTD"
@@ -106,16 +106,17 @@ function ChartBar({
           >
             <LocalizationProvider dateAdapter={AdapterMoment}>
               <DesktopDateRangePicker
+                className="chart-bar__date-range-picker"
                 startText="Start"
                 value={dateValue}
                 onChange={dateSelector}
                 style={{ color: 'black' }}
                 renderInput={(startProps, endProps) => (
-                  <>
-                    <TextField sx={{ ml: '10px' }} {...startProps} />
-                    <Box sx={{ mx: 2, color: 'black' }}> to </Box>
-                    <TextField sx={{ mr: '10px' }} {...endProps} />
-                  </>
+                  <Box className="chart-bar__date-panel">
+                    <TextField className="chart-bar__date-text" {...startProps} />
+                    <Box className="chart-bar__between-text"> to </Box>
+                    <TextField className="chart-bar__date-text" {...endProps} />
+                  </Box>
                 )}
               />
             </LocalizationProvider>

--- a/src/components/ChartContainer/ChartBar.js
+++ b/src/components/ChartContainer/ChartBar.js
@@ -217,7 +217,7 @@ ChartBar.defaultProps = {
   toggleFilterDrawer: undefined,
   filterSum: 0,
   currentTimeline: {
-    choice: '30',
+    choice: 'all',
     range: [null, null],
   },
   handleTimelineChange: undefined,

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -4,7 +4,6 @@ import {
 import React, {
   createContext, useState, useEffect,
 } from 'react';
-import moment from 'moment';
 import ChartBar from './ChartBar';
 import D3Chart from './D3Chart';
 import D3IndicatorByLineSelector from './D3IndicatorByLineSelector';
@@ -41,6 +40,11 @@ const defaultFilterState = {
   sum: 0,
 };
 
+const defaultTimelineState = {
+  choice: 'all', // 30, 60, ytd or custom.
+  range: [null, null],
+};
+
 function D3Container({ dashboardState, dashboardActions, store }) {
   const [displayData, setDisplayData] = useState(
     store.results.map((result) => ({ ...result })),
@@ -50,7 +54,7 @@ function D3Container({ dashboardState, dashboardActions, store }) {
   const [byLineMeasure, setByLineMeasure] = useState('');
   const [byLineDisplayData, setByLineDisplayData] = useState([]);
   const [selectedMeasures, setSelectedMeasures] = useState([]);
-  const [dateValue, setDateValue] = useState([null, null]);
+  const [currentTimeline, setCurrentTimeline] = useState(defaultTimelineState);
   const [graphWidth, setGraphWidth] = useState(window.innerWidth)
 
   const workingList = [];
@@ -84,7 +88,7 @@ function D3Container({ dashboardState, dashboardActions, store }) {
     }
   }, [setSelectedMeasures, setCurrentFilters, store.currentResults]);
 
-  const handleDisplayDataUpdate = (measures, filters, dates) => {
+  const handleDisplayDataUpdate = (measures, filters, timeline) => {
     let newDisplayData = store.results.map((result) => ({ ...result }));
     newDisplayData = newDisplayData.filter((result) => measures.includes(result.measure));
     if (filters.domainsOfCare.length > 0) {
@@ -111,24 +115,14 @@ function D3Container({ dashboardState, dashboardActions, store }) {
         );
       });
     }
-    if (dates) {
-      if (dates.startDate || dates.endDate) {
-        newDisplayData = newDisplayData.filter(
-          (result) => {
-            if (dates.startDate && dates.endDate) {
-              return (moment(result.date).unix() < moment(dates.endDate).unix()
-                && moment(result.date).unix() > moment(dates.startDate).unix())
-            }
-            if (dates.startDate && dates.endDate === null) {
-              return moment(result.date).unix() > moment(dates.startDate).unix()
-            }
-            if (dates.endDate && dates.startDate === null) {
-              return moment(result.date).unix() < moment(dates.endDate).unix()
-            }
-            return false;
-          },
-        )
-      }
+    if (timeline.choice !== 'all') {
+      let dayLimit = 0;
+      if (timeline.choice === '30' || timeline.choice === '60') {
+        dayLimit = new Date().getTime() - (parseInt(timeline.choice, 10) * 24 * 60 * 60 * 1000);
+      } else if (timeline.choice === 'ytd') {
+        dayLimit = new Date(new Date().getFullYear(), 0, 1).getTime();
+      } // Custom coming later.
+      newDisplayData = newDisplayData.filter((result) => new Date(result.date) > dayLimit);
     }
     setDisplayData(newDisplayData);
   };
@@ -155,12 +149,17 @@ function D3Container({ dashboardState, dashboardActions, store }) {
         ? [] : selectedMeasures.filter((result) => result !== event.target.value);
       setSelectedMeasures(newSelectedMeasures);
     }
-    handleDisplayDataUpdate(newSelectedMeasures, currentFilters, buildDates(dateValue));
+    handleDisplayDataUpdate(newSelectedMeasures, currentFilters, currentTimeline);
   };
 
   const handleFilterChange = (filterOptions) => {
     setCurrentFilters(filterOptions);
-    handleDisplayDataUpdate(selectedMeasures, filterOptions, buildDates(dateValue));
+    handleDisplayDataUpdate(selectedMeasures, filterOptions, currentTimeline);
+  }
+
+  const handleTimelineChange = (timelineUpdate) => {
+    setCurrentTimeline(timelineUpdate);
+    handleDisplayDataUpdate(selectedMeasures, currentFilters, timelineUpdate)
   }
 
   const handleByLineChange = (event) => {
@@ -175,15 +174,6 @@ function D3Container({ dashboardState, dashboardActions, store }) {
       )[0],
     );
   };
-
-  const buildDates = (dateState) => ({
-    startDate: dateState[0],
-    endDate: dateState[1],
-  })
-
-  const handleDateChange = (dates) => {
-    handleDisplayDataUpdate(selectedMeasures, currentFilters, dates);
-  }
 
   return (
     <div>
@@ -226,9 +216,8 @@ function D3Container({ dashboardState, dashboardActions, store }) {
             <ChartBar
               filterDrawerOpen={dashboardState.filterDrawerOpen}
               toggleFilterDrawer={dashboardActions.toggleFilterDrawer}
-              dateValue={dateValue}
-              changeDateValue={setDateValue}
-              handleDateChange={handleDateChange}
+              currentTimeline={currentTimeline}
+              handleTimelineChange={handleTimelineChange}
               filterSum={currentFilters.sum}
             />
           </Grid>


### PR DESCRIPTION
# Related Tickets

- [SAR-418](https://jira.amida-tech.com/browse/SAR-418)

# How Things Worked (or Didn't) Before This PR

We only had custom range options for the timeline.

# How Things Work Now (And How to Test)
Based on MVP design, I had to remove the custom range for a set of options. The existing custom options also used `moment.js`, which is obsolete. We'll need to rewrite that to use another library. Truth be told, I'm not thrilled with the date range picker for various reasons, among them that MUI might be moving it to a premium service. We'll figure that out in another ticket.

Options include all available data, 30 days, 60 days and YTD. 'All' is the default option and no filtering should be applied to it. Simply select options from the drop down and confirm that your choices are altered. Ideally, you want data that goes over 30 days old at the very least. Testing as far back as YTD would be a pain. 

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
