### PR TITLE
Commented out user variable in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder /app/ /app/
 RUN yarn install --frozen-lockfile && yarn cache clean
 # Up til this point should get cached and only re-run if dependencies change
 
-USER 50000:50000
+# USER 50000:50000
 
 EXPOSE 3000
 


### PR DESCRIPTION
# How Things Worked (or Didn't) Before This PR

Wouldn't build due to priviledged user error

# How Things Work Now (And How to Test)

Now it will, as the offending line has been removed in the dockerfile.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
