### PR TITLE
[SAR-447] - Fixed branch name in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ spec:
         }
         stage('Build Production with Kaniko') {
             when { 
-                expression {env.GIT_BRANCH == 'origin/master'} 
+                expression {env.GIT_BRANCH == 'origin/main'} 
             }
             steps {
                 container(name: 'kaniko', shell: '/busybox/sh') {


### PR DESCRIPTION
# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-447](https://jira.amida-tech.com/browse/SAR-447)

# How Things Worked (or Didn't) Before This PR

Jenkinsfile didn't have correct branch names preventing Jenkins from pushing the images to dockerhub

# How Things Work Now (And How to Test)

Branch name check has been changed to match correctly