### PR TITLE
[SAR-464] Temporary fixes.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   BrowserRouter,
   Switch,
@@ -10,49 +10,11 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
-// layouts
-
 import axios from 'axios';
 import Dashboard from './layouts/Dashboard';
 import Auth from './layouts/Auth';
 import NotFound from './notFound';
 import DatastoreProvider from './context/DatastoreProvider';
-
-export default function AuthExample() {
-  if (`${process.env.REACT_APP_AUTH}` === 'false') {
-    localStorage.removeItem('seenWelcome', 'yes');
-  }
-
-  const initialShowWelcome = !localStorage.getItem('seenWelcome') || !localStorage.getItem('token');
-  const [showWelcome, setShowWelcome] = React.useState(initialShowWelcome);
-
-  if (`${process.env.REACT_APP_AUTH}` === 'false') {
-    return returnValue(true, showWelcome, setShowWelcome);
-  }
-
-  let accessToken = localStorage.getItem('token');
-
-  if (accessToken) {
-    const loggedIn = validateAccessToken(accessToken);
-    if (!loggedIn) {
-      localStorage.removeItem('seenWelcome');
-    }
-    return returnValue(loggedIn, showWelcome, setShowWelcome);
-  }
-
-  const { hash } = window.location;
-  const urlParams = new URLSearchParams(hash);
-  accessToken = urlParams.get('access_token');
-
-  if (accessToken) {
-    localStorage.setItem('seenWelcome', 'yes');
-    localStorage.setItem('token', accessToken);
-    window.history.replaceState({}, document.title, '/');
-    return returnValue(true, showWelcome, setShowWelcome);
-  }
-
-  return returnValue(false, showWelcome, setShowWelcome);
-}
 
 const action = (setShowWelcome) => (
   <IconButton
@@ -68,48 +30,84 @@ const action = (setShowWelcome) => (
   </IconButton>
 );
 
-const returnValue = (loggedIn, showWelcome, setShowWelcome) => (
-  <>
-    <Snackbar
-      open={showWelcome}
-      autoHideDuration={6000}
-      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      onClose={() => setShowWelcome(false)}
-      message="Welcome to Saraswati, where knowledge is power."
-      action={action(setShowWelcome)}
-      sx={{
-        '& .MuiSnackbarContent-root': { backgroundColor: '#DFF4FC', color: '#263238' },
-      }}
-    />
-    <BrowserRouter>
-      <Switch>
-        <Route path="/auth">
-          <Auth />
-        </Route>
-        <Route exact path="/">
-          {loggedIn
-            ? (
-              <DatastoreProvider>
-                <Dashboard loggedIn={loggedIn} />
-              </DatastoreProvider>
-            )
-            : <Redirect to="/auth" />}
-        </Route>
-        <Route path="*">
-          <NotFound />
-        </Route>
-      </Switch>
-    </BrowserRouter>
-  </>
+export default function App() {
+  const [showWelcome, setShowWelcome] = useState(false);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [isLoaded, setLoaded] = useState(false);
 
-);
+  useEffect(() => { // Check for .env first.
+    if (`${process.env.REACT_APP_AUTH}` === 'false') {
+      setAuthenticated(true);
+      setLoaded(true);
+      return;
+    }
+
+    const { hash } = window.location;
+    const urlParams = new URLSearchParams(hash);
+    let accessToken = urlParams.get('access_token');
+    if (accessToken) { // Check if redirect.
+      setShowWelcome(true);
+      localStorage.setItem('token', accessToken);
+      setAuthenticated(true);
+      setLoaded(true);
+      window.history.replaceState({}, document.title, '/');
+      return;
+    }
+
+    accessToken = localStorage.getItem('token');
+    if (accessToken) { // Otherwise check existing token.
+      validateAccessToken(accessToken)
+        .then((loggedIn) => {
+          setAuthenticated(loggedIn);
+          setLoaded(true);
+        })
+    }
+  }, [setShowWelcome, setAuthenticated, setLoaded]);
+
+  return (
+    <>
+      <Snackbar
+        open={showWelcome}
+        autoHideDuration={6000}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        onClose={() => setShowWelcome(false)}
+        message="Welcome to Saraswati, where knowledge is power."
+        action={action(setShowWelcome)}
+        sx={{
+          '& .MuiSnackbarContent-root': { backgroundColor: '#DFF4FC', color: '#263238' },
+        }}
+      />
+      <BrowserRouter>
+        <Switch>
+          <Route path="/auth">
+            <Auth />
+          </Route>
+          <Route exact path="/">
+            {isLoaded
+              && (authenticated ? (
+                <DatastoreProvider>
+                  <Dashboard loggedIn={authenticated} />
+                </DatastoreProvider>
+              ) : <Redirect to="/auth" />
+              )}
+          </Route>
+          <Route path="*">
+            <NotFound />
+          </Route>
+        </Switch>
+      </BrowserRouter>
+    </>
+  )
+}
 
 const validateAccessToken = async (accessToken) => {
   try {
-    await axios.get(`${process.env.REACT_APP_TOKENINFO}?access_token=${accessToken}`);
+    const res = await axios.get(`${process.env.REACT_APP_TOKENINFO}?access_token=${accessToken}`);
+    if (res.status === 200) {
+      return true;
+    }
   } catch (error) {
     localStorage.removeItem('token');
-    window.location.replace(`${process.env.REACT_APP_DASHBOARD_URL}/auth`);
   }
-  return true;
+  return false;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -61,6 +61,8 @@ export default function App() {
           setAuthenticated(loggedIn);
           setLoaded(true);
         })
+    } else {
+      setLoaded(true);
     }
   }, [setShowWelcome, setAuthenticated, setLoaded]);
 


### PR DESCRIPTION
# Related Tickets

- [SAR-463](https://jira.amida-tech.com/browse/SAR-463)

# Other Repos' PR(s) Intended to Work With This PR

- LINK_TO_THE_PR or "None."

# How Things Worked (or Didn't) Before This PR
Initially we were getting a propType error back regarding the `loggedIn`.

# How Things Work Now (And How to Test)
I believe I got it but I identified changes I felt were necessary. The way it works now is that it holds loading the application until it verifies that you're already signed in either through the `.env` variable `REACT_APP_AUTH` being false, or if there's a valid access token in your local storage (it will check).

If your local storage token doesn't throw a 200, you will be booted back to the auth page. If you're signing in from scratch (nothing in local storage), it scrapes the `access_token` from the redirect URL, stores it in local storages, and removes the URL from the browser's navigation bar. This seemed janky but I think it was the only real way to do it... @anthem123 weigh in on this?

Anyway, that last point, the "sign in without access token," will pop up the welcome `Snackbar`. Anything else won't. 

Please test carefully. 

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
