### PR TITLE
[SAR-511]: Option to use new data for trends

### DIFF
--- a/src/context/DatastoreProvider.js
+++ b/src/context/DatastoreProvider.js
@@ -10,10 +10,11 @@ import { DatastoreReducer, initialState } from './DatastoreReducer';
 
 const axios = require('axios').default;
 
-const searchUrl = process.env.REACT_APP_LEGACY_RESULTS === 'true'
+const useLegacyResults = process.env.REACT_APP_LEGACY_RESULTS;
+const searchUrl = useLegacyResults === 'true'
   ? new URL(`${process.env.REACT_APP_HEDIS_MEASURE_API_URL}measures/searchResults`)
   : new URL(`${process.env.REACT_APP_HEDIS_MEASURE_API_URL}measures/dailyMeasureResults`);
-const trendUrl = new URL(`${process.env.REACT_APP_HEDIS_MEASURE_API_URL}measures/trends`);
+const trendUrl = new URL(`${process.env.REACT_APP_HEDIS_MEASURE_API_URL}measures/trends?legacyResults=${useLegacyResults}`);
 const infoUrl = new URL(`${process.env.REACT_APP_HEDIS_MEASURE_API_URL}measures/info`);
 const devData = `${process.env.REACT_APP_DEV_DATA}`;
 


### PR DESCRIPTION
# Related Tickets

- [SAR-511](https://jira.amida-tech.com/browse/SAR-511)

# Other Repos' PR(s) Intended to Work With This PR

- [HeRA PR 42](https://github.com/amida-tech/saraswati-hedis-results-api/pull/42)

# How Things Work Now (And How to Test)

Can switch between legacy and new result data for trends. Useful if you haven't used `test-data-generator.js` yet.

And if you haven't done so yet, use it!