### PR TITLE
Feature/sar 506 overview vs member toggle

### DIFF
--- a/src/assets/styles/_d3-container.scss
+++ b/src/assets/styles/_d3-container.scss
@@ -14,10 +14,55 @@ $block-class: 'd3-container';
             margin-top: 3.5rem;
         }
 
-        & &__selector-title {
-            color: $default-black;
-            margin: .85rem 1rem 0 0;
+        & &__return-icon {
+            font-size: 1rem;
+            margin-bottom: .25rem;
+        }
+
+        &__return-link-display {
+            cursor: pointer;
+        }
+
+        & &__return-measure-display {
+            display: flex;
+            flex-direction: row;
+            position: absolute;
+            margin: .75rem 0;
+        }
+
+        & &__cancel-icon {
+            color: $blue-light;
+            font-size: 2rem;
+            margin: .5rem;
+        }
+
+        & &__return-measure-labels {
+            display: flex;
+            flex-direction: column;
+            color: $blue-grey-darken-4;
+            font-size: 1.2rem;
+        }
+
+        & &__return-measure-title {
+            font-size: 1.5rem;
+            font-weight: bold;
+        }
+
+        & &__title {
+            color: $blue-grey-darken-2;
             font-size: 1.1rem;
+            text-transform: uppercase;
+            font-weight: bold;
+
+            &--inactive {
+                color: $blue-grey-lighten-1;
+            }
+        }
+
+        & &__selector-title {
+            color: $blue-grey-darken-4;
+            font-size: 1.1rem;
+            margin: .85rem 1rem 0 0;
         }
 
         &__measure-selector {

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -3,6 +3,8 @@ import React, {
 } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Grid, Typography } from '@mui/material';
+import DisabledByDefaultRoundedIcon from '@mui/icons-material/DisabledByDefaultRounded';
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import DisplayTable from '../DisplayTable/DisplayTable';
 import ChartBar from './ChartBar';
 import D3Chart from './D3Chart';
@@ -27,6 +29,10 @@ import {
 } from './D3ContainerUtils';
 
 export const firstRenderContext = createContext(true);
+
+function onReturnClick(history) {
+  history.push('/');
+}
 
 const colorArray = [
   '#88CCEE',
@@ -54,6 +60,19 @@ const defaultTimelineState = {
   choice: 'all', // 30, 60, ytd or custom.
   range: [null, null],
 };
+
+function labelGenerator(measure) {
+  if (!measure?.label) {
+    return '';
+  }
+  const { label } = measure;
+  return (
+    <Grid className="d3-container__return-measure-labels">
+      <Typography className="d3-container__return-measure-title">{label.substring(0, label.indexOf(' '))}</Typography>
+      <Typography className="d3-container__return-measure-description">{label.substring(label.indexOf('- ') + 1)}</Typography>
+    </Grid>
+  )
+}
 
 function D3Container({
   activeMeasure, dashboardState, dashboardActions, store,
@@ -86,7 +105,7 @@ function D3Container({
       value: item.measure,
       color: index <= 11 ? colorArray[index] : colorArray[index % 11],
     }));
-    if (activeMeasure.measure === 'composite') {
+    if (activeMeasure.measure === 'composite' || activeMeasure.measure === '') {
       setComposite(true);
       setDisplayData(store.results.map((result) => ({ ...result })));
       setCurrentResults(store.currentResults);
@@ -167,6 +186,22 @@ function D3Container({
         currentFilters={currentFilters}
         handleFilterChange={handleFilterChange}
       />
+      { isComposite
+        ? <Typography className="d3-container__title d3-container__title--inactive">All Measures</Typography>
+        : (
+          <Grid className="d3-container__return-link-display" onClick={() => onReturnClick(history)}>
+            <Typography className="d3-container__title">
+              <ArrowBackIosIcon className="d3-container__return-icon" />
+              All Measures
+            </Typography>
+            <Grid className="d3-container__return-measure-display">
+              <DisabledByDefaultRoundedIcon className="d3-container__cancel-icon" />
+              {labelGenerator(
+                currentResults.find((result) => result.measure === activeMeasure.measure),
+              )}
+            </Grid>
+          </Grid>
+        ) }
       <Grid item className="d3-container__chart-bar">
         <ChartBar
           filterDrawerOpen={dashboardState.filterDrawerOpen}

--- a/src/components/ChartContainer/D3Props.js
+++ b/src/components/ChartContainer/D3Props.js
@@ -20,7 +20,7 @@ export const activeMeasureProps = PropTypes.shape({
 });
 
 export const defaultActiveMeasure = {
-  measure: 'composite',
+  measure: '',
   denominator: 0,
   shortLabel: '',
   starRating: 0,

--- a/src/components/DisplayTable/DisplayTable.js
+++ b/src/components/DisplayTable/DisplayTable.js
@@ -13,6 +13,7 @@ function DisplayTable({
   rowData,
   headerInfo,
   pageSize,
+  isComposite,
   useCheckBox,
   handleCheckBoxChange,
   selectedRows,
@@ -25,6 +26,7 @@ function DisplayTable({
     pageCount = Math.ceil(rowData.length / pageSize);
   }
   const pageData = usePagination(rowData, pageSize);
+  const linkPrefix = isComposite ? '' : 'member/';
 
   const handleChange = (_e, p) => {
     setCurrentPage(p);
@@ -51,13 +53,12 @@ function DisplayTable({
             rowDataItem={item}
             headerInfo={headerInfo}
             useCheckBox={useCheckBox}
+            linkPrefix={linkPrefix}
             handleCheckBoxEvent={handleCheckBoxChange}
             rowSelected={selectedRows.includes(item.value)}
             color={colorMapping.find((mapping) => mapping.value === item.value)?.color || '#000'}
           />
-
         </Grid>
-
       ))}
       {pageCount > 0 && (
       <StyledEngineProvider injectFirst>
@@ -97,6 +98,7 @@ DisplayTable.propTypes = {
     }),
   ),
   pageSize: PropTypes.number,
+  isComposite: PropTypes.bool,
   useCheckBox: PropTypes.bool,
   handleCheckBoxChange: PropTypes.func,
   selectedRows: PropTypes.arrayOf(
@@ -109,6 +111,7 @@ DisplayTable.defaultProps = {
   rowData: [],
   headerInfo: [],
   pageSize: 0,
+  isComposite: false,
   useCheckBox: false,
   handleCheckBoxChange: () => undefined,
   selectedRows: [],

--- a/src/components/DisplayTable/TableRow.js
+++ b/src/components/DisplayTable/TableRow.js
@@ -3,10 +3,11 @@ import {
 } from '@mui/material';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import CheckBoxCell from './CheckBoxCell';
 
 function TableRow({
-  rowDataItem, headerInfo, useCheckBox, handleCheckBoxEvent, rowSelected, color,
+  rowDataItem, headerInfo, useCheckBox, linkPrefix, handleCheckBoxEvent, rowSelected, color,
 }) {
   return (
     <Box className="display-table-row">
@@ -31,7 +32,15 @@ function TableRow({
             }}
           >
             <Typography variant="caption" className="display-table-row__data">
-              {rowDataItem[fieldInfo.key]}
+              {fieldInfo.link && rowDataItem.value !== 'composite'
+                ? (
+                  <Link
+                    to={{ pathname: `/${linkPrefix}${rowDataItem.value}` }}
+                  >
+                    {rowDataItem[fieldInfo.key]}
+                  </Link>
+                )
+                : rowDataItem[fieldInfo.key]}
             </Typography>
           </Grid>
         ))}
@@ -53,6 +62,7 @@ TableRow.propTypes = {
     }),
   ),
   useCheckBox: PropTypes.bool,
+  linkPrefix: PropTypes.string,
   handleCheckBoxEvent: PropTypes.func,
   rowSelected: PropTypes.bool,
   color: PropTypes.string,
@@ -62,6 +72,7 @@ TableRow.defaultProps = {
   rowDataItem: {},
   headerInfo: [],
   useCheckBox: false,
+  linkPrefix: '',
   handleCheckBoxEvent: () => undefined,
   rowSelected: false,
   color: '',

--- a/src/components/Utilites/MeasureTable.js
+++ b/src/components/Utilites/MeasureTable.js
@@ -57,6 +57,7 @@ const headerData = (isComposite) => {
 const headerInfo = [
   {
     key: 'label',
+    link: true,
     header: 'Measure',
     tooltip: measureTip,
     flexBasis: 22,

--- a/src/components/Utilites/PatientTable.js
+++ b/src/components/Utilites/PatientTable.js
@@ -1,0 +1,31 @@
+const memberIdTip = 'The patient\'s member ID.';
+const pageSize = 10;
+
+// These will change based on the measurement.
+const headerData = () => headerInfo;
+
+const headerInfo = [
+  {
+    key: 'label',
+    link: true,
+    header: 'MemberID',
+    tooltip: memberIdTip,
+    flexBasis: 22,
+  },
+];
+
+const formatData = (patientResults) => {
+  const formattedData = [];
+  patientResults.forEach((result) => {
+    formattedData.push({
+      value: result.memberId,
+      label: result.memberId,
+      type: 'patient',
+    });
+  });
+  return formattedData;
+};
+
+module.exports = {
+  headerData, pageSize, formatData,
+};


### PR DESCRIPTION
# Related Tickets

- [SAR-506(https://jira.amida-tech.com/browse/SAR-506)
- [SAR-530(https://jira.amida-tech.com/browse/SAR-530)
- [SAR-291(https://jira.amida-tech.com/browse/SAR-291)

# Other Repos' PR(s) Intended to Work With This PR

- LINK_TO_THE_PR or "None."

# How Things Worked (or Didn't) Before This PR
From the submeasures view, there are now links that return to the main "composite" measure view, a toggle that switches the submeasures between overview and member view, and links in the "composite" view and member views so you can go by clicking on those.

# How Things Work Now (And How to Test)
Please test it carefully for any errors. Trying going directly to pages too. 

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
