### PR TITLE
Feature/sar 565 patient table filters

### DIFF
--- a/src/assets/styles/App.scss
+++ b/src/assets/styles/App.scss
@@ -15,6 +15,7 @@
 @use 'navbar';
 @use 'report-builder';
 @use 'saved-queries';
+@use 'table-filter-panel';
 @use 'trend-display';
 @use 'patient-table-row';
 @use 'rating-trends';

--- a/src/assets/styles/_display-table.scss
+++ b/src/assets/styles/_display-table.scss
@@ -36,7 +36,7 @@ $block-class: 'display-table';
         & &__title {
             word-wrap: break-word;
             font-weight: bold;
-            color:$blue-grey-darken-1;
+            color: $blue-grey-darken-1;
         }
 
         & &__help-icon {

--- a/src/assets/styles/_table-filter-panel.scss
+++ b/src/assets/styles/_table-filter-panel.scss
@@ -1,0 +1,27 @@
+$block-class: 'table-filter-panel';
+@import 'colors';
+
+@at-root {
+    .#{$block-class} {
+        & &__button-panel {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            margin: 1rem 2rem;
+            color:$blue-grey-darken-1;
+        }
+
+        & &__label {
+            align-items: center;
+            padding: 0.5625rem;
+            font-weight: bolder;
+            word-wrap: break-word;
+        }
+
+        & &__divider {
+            width: 100%;
+            background-color: $blue-grey-lighten-3;
+            height: 1px;
+        }
+    }
+}

--- a/src/assets/styles/_table-filter-panel.scss
+++ b/src/assets/styles/_table-filter-panel.scss
@@ -6,7 +6,7 @@ $block-class: 'table-filter-panel';
         & &__button-panel {
             display: flex;
             flex-direction: row;
-            justify-content: space-between;
+            justify-content: space-around;
             margin: 1rem 2rem;
             color:$blue-grey-darken-1;
         }

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -284,7 +284,12 @@ function D3Container({
               />
               <DisplayTable
                 tableType="patient"
-                rowData={PatientTable.formatData(patientResults, selectedMeasures, store.info)}
+                rowData={PatientTable.formatData(
+                  patientResults,
+                  selectedMeasures,
+                  store.info,
+                  tableFilter,
+                )}
                 headerInfo={PatientTable.headerData(
                   selectedMeasures,
                   store.info,

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -8,6 +8,7 @@ import {
 import DisabledByDefaultRoundedIcon from '@mui/icons-material/DisabledByDefaultRounded';
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import env from '../../env';
+import TableFilterPanel from '../DisplayTable/TableFilterPanel';
 import DisplayTable from '../DisplayTable/DisplayTable';
 import ChartBar from './ChartBar';
 import D3Chart from './D3Chart';
@@ -97,6 +98,7 @@ function D3Container({
   const [filterDisabled, setFilterDisabled] = useState(true);
   const [patientView, setPatientView] = useState(false);
   const [patientResults, setPatientResults] = useState([]);
+  const [tableFilter, setTableFilter] = useState('');
 
   useEffect(() => {
     function handleResize() {
@@ -121,6 +123,7 @@ function D3Container({
       setColorMap(baseColorMap);
       setFilterDisabled(false);
       setPatientResults([]);
+      setTableFilter('');
     } else {
       setComposite(false);
       const subMeasureCurrentResults = getSubMeasureCurrentResults(activeMeasure, store);
@@ -196,7 +199,11 @@ function D3Container({
 
   const handleMeasureChange = (event) => {
     history.push(`/${event.target.value === 'composite' ? '' : event.target.value}`);
-  };
+  }
+
+  const handleTableFilterChange = (event) => {
+    setTableFilter(event.target.value === tableFilter ? '' : event.target.value);
+  }
 
   return (
     <div className="d3-container">
@@ -268,17 +275,26 @@ function D3Container({
           )}
         { patientView
           ? (
-            <DisplayTable
-              tableType="patient"
-              rowData={PatientTable.formatData(patientResults, selectedMeasures, store.info)}
-              headerInfo={PatientTable.headerData(
-                selectedMeasures,
-                store.info,
-              )}
-              pageSize={PatientTable.pageSize}
-              isComposite={isComposite}
-              useCheckBox={false}
-            />
+            <>
+              <TableFilterPanel
+                measure={activeMeasure.measure}
+                patientResult={patientResults[0]}
+                tableFilter={tableFilter}
+                handleTableFilterChange={handleTableFilterChange}
+              />
+              <DisplayTable
+                tableType="patient"
+                rowData={PatientTable.formatData(patientResults, selectedMeasures, store.info)}
+                headerInfo={PatientTable.headerData(
+                  selectedMeasures,
+                  store.info,
+                )}
+                pageSize={PatientTable.pageSize}
+                isComposite={isComposite}
+                useCheckBox={false}
+                handleCheckBoxChange={handleSelectedMeasureChange}
+              />
+            </>
           )
           : (
             <DisplayTable
@@ -288,9 +304,9 @@ function D3Container({
               pageSize={MeasureTable.pageSize}
               isComposite={isComposite}
               useCheckBox
-              handleCheckBoxChange={handleSelectedMeasureChange}
               selectedRows={selectedMeasures}
               colorMapping={colorMap}
+              handleTableFilterChange={handleTableFilterChange}
             />
           )}
       </Grid>

--- a/src/components/DisplayTable/DisplayTable.js
+++ b/src/components/DisplayTable/DisplayTable.js
@@ -16,9 +16,9 @@ function DisplayTable({
   headerInfo,
   pageSize,
   useCheckBox,
-  handleCheckBoxChange,
   selectedRows,
   colorMapping,
+  handleCheckBoxChange,
 }) {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -112,11 +112,11 @@ DisplayTable.propTypes = {
   pageSize: PropTypes.number,
   isComposite: PropTypes.bool,
   useCheckBox: PropTypes.bool,
-  handleCheckBoxChange: PropTypes.func,
   selectedRows: PropTypes.arrayOf(
     PropTypes.string,
   ),
   colorMapping: colorMappingProps,
+  handleCheckBoxChange: PropTypes.func,
 };
 
 DisplayTable.defaultProps = {
@@ -126,9 +126,9 @@ DisplayTable.defaultProps = {
   pageSize: 0,
   isComposite: false,
   useCheckBox: false,
-  handleCheckBoxChange: () => undefined,
   selectedRows: [],
   colorMapping: [],
+  handleCheckBoxChange: () => undefined,
 }
 
 export default DisplayTable;

--- a/src/components/DisplayTable/TableFilterPanel.js
+++ b/src/components/DisplayTable/TableFilterPanel.js
@@ -5,9 +5,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const patientComplianceItems = [
-  { label: '1 Non-Compliant Issue', value: 'one' },
-  { label: '2 Non-Compliant Issues', value: 'two' },
-  { label: 'More than 2 Non-Compliant Issues', value: 'many' },
+  { label: '1 Non-Compliant Submeasure', value: 'one' },
+  { label: '2 Non-Compliant Submeasures', value: 'two' },
+  { label: 'More than 2 Non-Compliant Submeasures', value: 'many' },
 ];
 
 const numeratorValues = ['id', 'Numerator 2', 'Numerator 3'];

--- a/src/components/DisplayTable/TableFilterPanel.js
+++ b/src/components/DisplayTable/TableFilterPanel.js
@@ -1,0 +1,62 @@
+import {
+  Box, Checkbox, Divider, FormGroup, FormControlLabel, Typography,
+} from '@mui/material';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const patientComplianceItems = [
+  { label: '1 Non-Compliant Issue', value: 'one' },
+  { label: '2 Non-Compliant Issues', value: 'two' },
+  { label: 'More than 2 Non-Compliant Issues', value: 'many' },
+];
+
+const numeratorValues = ['id', 'Numerator 2', 'Numerator 3'];
+
+function TableFilterPanel({
+  measure, patientResult, tableFilter, handleTableFilterChange,
+}) {
+  const numeratorCheck = patientResult[
+    Object.keys(patientResult).find((key) => key.startsWith(measure))];
+  return (
+    <Box className="table-filter-panel">
+      <FormGroup className="table-filter-panel__button-panel">
+        <Typography className="table-filter-panel__label">
+          Member Compliance:
+        </Typography>
+        {patientComplianceItems.map((item, index) => (
+          <FormControlLabel
+            key={`table-filter-panel-${item.value}`}
+            componentsProps={{ typography: { className: 'table-filter-panel__filter-item' } }}
+            disabled={numeratorCheck?.[numeratorValues[index]] === undefined}
+            control={(
+              <Checkbox
+                checked={tableFilter === item.value}
+                value={item.value}
+                className="table-filter-panel__filter-checkbox"
+                onChange={(e) => handleTableFilterChange(e)}
+              />
+                )}
+            label={item.label}
+          />
+        ))}
+      </FormGroup>
+      <Divider className="table-filter-panel__divider" />
+    </Box>
+  )
+}
+
+TableFilterPanel.propTypes = {
+  measure: PropTypes.string,
+  patientResult: PropTypes.shape({}),
+  tableFilter: PropTypes.string,
+  handleTableFilterChange: PropTypes.func,
+};
+
+TableFilterPanel.defaultProps = {
+  measure: '',
+  patientResult: {},
+  tableFilter: '',
+  handleTableFilterChange: () => undefined,
+}
+
+export default TableFilterPanel;

--- a/src/components/Utilites/PatientTable.js
+++ b/src/components/Utilites/PatientTable.js
@@ -116,7 +116,9 @@ const filterByNonCompliance = (formattedData, selectedMeasures, tableFilter) => 
     return formattedData;
   }
   const filteredData = [];
-  const limit = nonComplianceRange[tableFilter];
+  const limit = nonComplianceRange[tableFilter] < 3
+    ? (check) => check === nonComplianceRange[tableFilter]
+    : (check) => check >= nonComplianceRange[tableFilter];
   formattedData.forEach((score) => {
     let nonComplianceCheck = 0;
     selectedMeasures.forEach((measure) => {
@@ -124,7 +126,7 @@ const filterByNonCompliance = (formattedData, selectedMeasures, tableFilter) => 
         nonComplianceCheck += 1;
       }
     });
-    if (nonComplianceCheck === limit || (limit === 3 && nonComplianceCheck >= limit)) {
+    if (limit(nonComplianceCheck)) {
       filteredData.push(score);
     }
   });

--- a/src/components/Utilites/PatientTable.js
+++ b/src/components/Utilites/PatientTable.js
@@ -51,7 +51,7 @@ const allValuesEqual = (valueArray) => {
   return true;
 }
 
-const formatData = (patientResults, selectedMeasures, storeInfo) => {
+const formatData = (patientResults, selectedMeasures, storeInfo, tableFilter) => {
   const formattedData = [];
 
   patientResults.forEach((patientResult) => {
@@ -102,8 +102,34 @@ const formatData = (patientResults, selectedMeasures, storeInfo) => {
     formattedData.push(formattedResult);
   });
 
-  return formattedData;
+  return filterByNonCompliance(formattedData, selectedMeasures, tableFilter);
 };
+
+const nonComplianceRange = {
+  one: 1,
+  two: 2,
+  many: 3,
+}
+
+const filterByNonCompliance = (formattedData, selectedMeasures, tableFilter) => {
+  if (tableFilter === '') {
+    return formattedData;
+  }
+  const filteredData = [];
+  const limit = nonComplianceRange[tableFilter];
+  formattedData.forEach((score) => {
+    let nonComplianceCheck = 0;
+    selectedMeasures.forEach((measure) => {
+      if (score[measure] === 'false') {
+        nonComplianceCheck += 1;
+      }
+    });
+    if (nonComplianceCheck === limit || (limit === 3 && nonComplianceCheck >= limit)) {
+      filteredData.push(score);
+    }
+  });
+  return filteredData;
+}
 
 module.exports = {
   headerData, pageSize, formatData,

--- a/src/components/Utilites/PatientTable.js
+++ b/src/components/Utilites/PatientTable.js
@@ -106,9 +106,9 @@ const formatData = (patientResults, selectedMeasures, storeInfo, tableFilter) =>
 };
 
 const nonComplianceRange = {
-  one: 1,
-  two: 2,
-  many: 3,
+  one: 2,
+  two: 3,
+  many: 4,
 }
 
 const filterByNonCompliance = (formattedData, selectedMeasures, tableFilter) => {
@@ -116,7 +116,15 @@ const filterByNonCompliance = (formattedData, selectedMeasures, tableFilter) => 
     return formattedData;
   }
   const filteredData = [];
-  const limit = nonComplianceRange[tableFilter] < 3
+  if (selectedMeasures.length === 1) {
+    formattedData.forEach((score) => {
+      if (score[selectedMeasures[0]] === 'false') {
+        filteredData.push(score);
+      }
+    });
+    return filteredData;
+  }
+  const limit = nonComplianceRange[tableFilter] < 4
     ? (check) => check === nonComplianceRange[tableFilter]
     : (check) => check >= nonComplianceRange[tableFilter];
   formattedData.forEach((score) => {


### PR DESCRIPTION
# Related Tickets

- [SAR-565](https://jira.amida-tech.com/browse/SAR-565)

# Other Repos' PR(s) Intended to Work With This PR

- LINK_TO_THE_PR or "None."

# How Things Worked (or Didn't) Before This PR
There was no patient table filters that removed levels of noncompliance.

# How Things Work Now (And How to Test)
Now there are.

The `TableFilterPanel` is separate from `DisplayTable` in that it sits atop of it. It's not 100% generic, but it wouldn't take much to do so. We'd need to extrapolate a few more elements to let it work with Providers and Healthcare Plans. I can take point on that.

Note that for the filters **only one checkbox should be selected.** If another is, that should become the selected one. If it is reclicked, none should be selected.

Lastly, the logic for the non-compliance is in `PatientTable` and the filter results are passed to `formatData()`. 

To test:

1. You want a few different data sets. AAB is a good one. **Avoid CIS-E because it is broken visually.**
2. Check that for measures with only 1 or 2 submeasures, "2 Non-Compliant Issues" and "More than 2 Non-Compliant Issues" should be disabled. What it's doing is taking a sample record and checking the keys to see if `id`, `Numerator 2` and `Numerator 3` exists, and disabling filters that aren't applicable. I recommend checking with AAB, ASFE and CSS for just 1 submeasure and COU, FUM and DSFE for 2 submeasures.  (Thought, maybe it would be better to check `hedis-info.json`? Can make a ticket to fix.)
3. When you click on a filter, you should ensure that only the selected amounts should be non-compliant. So if is says 1 Non-Compliant, then there should be 1 Unmatched only. 

# Readiness

1. [ ] This PR passes all automated tests.
5. [ ] This PR has no linting errors.
6. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
