### PR TITLE
SAR 596: Move screen to top using back link

### DIFF
--- a/src/ProtectedRoutes.js
+++ b/src/ProtectedRoutes.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from '@emotion/react';
 import PropTypes from 'prop-types';
+import ScrollToTop from './components/Utilities/ScrollToTop'
 import Navbar from './components/Common/Navbar'
 import Footer from './components/Common/Footer';
 import theme from './assets/styles/AppTheme';
@@ -16,6 +17,7 @@ export default function ProtectedRoute({ authenticated }) {
     <DatastoreProvider>
       <ThemeProvider theme={theme}>
         <Navbar />
+        <ScrollToTop />
         <Switch>
           <Route path="/reports" component={Reports} />
           <Route path="/member/:id" render={({ match }) => <MemberReport id={match.params.id} />} />

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -24,7 +24,6 @@ import FilterDrawer from '../FilterMenu/FilterDrawer';
 
 import ColorMapping from '../Utilities/ColorMapping';
 import MeasureTable from '../Utilities/MeasureTable';
-import PatientTable from '../Utilities/PatientTable';
 import MemberTable from '../Utilities/MemberTable';
 import MeasureTableRow from '../DisplayTable/MeasureTableRow';
 import MemberTableRow from '../DisplayTable/MemberTableRow';

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -25,6 +25,7 @@ import FilterDrawer from '../FilterMenu/FilterDrawer';
 import ColorMapping from '../Utilities/ColorMapping';
 import MeasureTable from '../Utilities/MeasureTable';
 import PatientTable from '../Utilities/PatientTable';
+
 import MeasureTableRow from '../DisplayTable/MeasureTableRow';
 import PatientTableRow from '../DisplayTable/PatientTableRow';
 import {

--- a/src/components/Utilities/ScrollToTop.js
+++ b/src/components/Utilities/ScrollToTop.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollToTop({ history }) {
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+    return () => {
+      unlisten();
+    }
+  }, [history]);
+
+  return (null);
+}
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
# Related Tickets

- [SAR-596](https://jira.amida-tech.com/browse/SAR-596)

# Other Repos' PR(s) Intended to Work With This PR

None.

# How Things Worked (or Didn't) Before This PR
When a user selects a measure or uses a back button, the window didn't scroll to the top for the illusion of a new page.

# How Things Work Now (And How to Test)
When a user navigates to a measure through a back button, dropdown menu, or selection table, the page should scroll to the top. As we add onto the project, any other navigation-like behaviour will function the same.

# Readiness

1. [X] This PR passes all automated tests.
2. [X] This PR has no linting errors.
3. [X] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
