### PR TITLE
SAR 594: Change tab styling

### DIFF
--- a/src/assets/styles/_chart-bar.scss
+++ b/src/assets/styles/_chart-bar.scss
@@ -56,7 +56,7 @@ $block-class: 'chart-bar';
       }
 
       .MuiPickersDay-today {
-        color: $blue-main;
+        color: $blue-today;
       }
     }
   }

--- a/src/assets/styles/_d3-chart.scss
+++ b/src/assets/styles/_d3-chart.scss
@@ -54,7 +54,7 @@ $block-class: 'd3-chart';
       padding: 5px 10px;
       font-size: 1rem;
       font-weight: bold;
-      border-radius: 10px;
+      border-radius: 3px;
       visibility: hidden;
       white-space: pre-line;
     }

--- a/src/assets/styles/_d3-container.scss
+++ b/src/assets/styles/_d3-container.scss
@@ -8,34 +8,41 @@ $block-class: 'd3-container';
         & &__overview-member-chart {
             margin: 0 -1rem;
             border: $blue-dark solid 1px;
-            border-radius: 2px 2px 0px 0px;
+            border-radius: 3px;
         }
 
+        // MUI TABS
+        // height: 4rem;
+        // align-items: center;
+
         & &__table-tab-bar {
-            background-color: $blue-dark;
+            height: 4rem;
+            background-color: $blue-light;
             outline: $blue-dark solid 1px;
         }
 
         & &__table-selection-button {
-            color: $blue-grey-lighten-3;
+            color: $blue-light-2;
             max-height: 2.2rem;
             font-weight: light;
             padding: 0 2rem;
             border: unset;
             text-transform: capitalize;
-            font-size: 1.5rem;
+            font-size: 1.3rem;
             margin: 1rem .5rem;
         }
 
         & &__table-selection-button:hover, :focus {
             border-radius: 0.5rem;
+            background-color: $blue-light-2-transparent;
+            transition: 200ms;
         }
 
         & &__table-selection-button.Mui-selected {
-            color: $blue-light-2;
-            background-color: $blue-light;
+            color: $blue-light;
+            background-color: $blue-light-2;
             border-radius: 0.5rem;
-            height: 2rem;
+            height: 1.5rem;
             place-self: center;
         }
 
@@ -66,6 +73,7 @@ $block-class: 'd3-container';
 
         &__return-link-display {
             cursor: pointer;
+            width: fit-content;
         }
 
         & &__return-measure-display {

--- a/src/assets/styles/_display-table.scss
+++ b/src/assets/styles/_display-table.scss
@@ -130,7 +130,7 @@ $block-class: 'display-table';
 
     .MuiPaginationItem-root {
         color: $blue-grey-darken-1;
-        border-radius: 0.5rem;
+        border-radius: 3px;
         border: .1rem solid $blue-grey-lighten-3;
     }
 

--- a/src/assets/styles/_info.scss
+++ b/src/assets/styles/_info.scss
@@ -26,7 +26,7 @@ $block-class: 'info';
       &__info-box {
         background-color: $blue-light-2;
         display: flex;
-        border-radius: .75rem;
+        border-radius: 3px;
         padding: .9rem;
         max-width: 600px;
         position: absolute;

--- a/src/assets/styles/_rating-trends.scss
+++ b/src/assets/styles/_rating-trends.scss
@@ -33,7 +33,7 @@ $block-class: 'rating-trends';
         &__panel {
             height: 11rem;
             border: 1px solid $blue-grey-lighten-3;
-            border-radius: .75rem;
+            border-radius: 3px;
             text-align: center;
             margin: 1rem;
             padding: 1rem;
@@ -94,7 +94,7 @@ $block-class: 'rating-trends';
             font-weight: 600;
             border: 1px solid $default-gray;
             padding: 1rem;
-            border-radius: 0.25rem;
+            border-radius: 3px;
         }
     }
 }

--- a/src/assets/styles/colors.scss
+++ b/src/assets/styles/colors.scss
@@ -4,15 +4,16 @@ $default-green: #2E7D32;
 $default-black: #263238;
 $default-mint: #3EB489;
 
+// this can be integrated into the main palette
 $gray-main: #616161;
 $gray-light: #CFDFDC;
 $gray-dark: #666666;
 
-$blue-main: #4269f5;
-$blue-light: #1976D2;
-$blue-light-2: #DFF4FC;
-$blue-denim: #0a65bf;
-$blue-dark: #162f8a;
+$blue-light: #1976D2; // good background/main color for components
+$blue-light-2: #DFF4FC; // good background/secondary color with blue-light under it
+$blue-light-2-transparent: #dff4fc40; //niche hover case color
+$blue-today: #4269f5; // used only for 'today' on MUI chart currently, not our true main
+$blue-dark: #162f8a; //outline for blue-light components
 
 $y-axis-line-color: #cfd8dc;
 $axis-label-color: #b0bec5;

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -287,7 +287,7 @@ function D3Container({
         <Box className="d3-container__overview-member-chart">
           <TabContext value={tabValue}>
             <Box className="d3-container__table-tab-bar">
-              <TabList TabIndicatorProps={{ style: { backgroundColor: 'transparent' } }} sx={{ marginLeft: '8rem' }} onChange={handleTabChange} aria-label="overview and members tabs">
+              <TabList TabIndicatorProps={{ style: { backgroundColor: 'transparent' } }} sx={{ marginLeft: '8rem', height: '4rem', alignItems: 'center' }} onChange={handleTabChange} aria-label="overview and members tabs">
                 <Tab className="d3-container__table-selection-button" label="Overview" value="overview" />
                 {!isComposite && <Tab className="d3-container__table-selection-button" label="Members" value="members" />}
               </TabList>


### PR DESCRIPTION
Changes:
Fixed long button bug on "all measures" return button
Unified border-radius style across stylesheets on main components
Corrected colors on tab buttons
Added some usage notes on colors.scss until color sheets are refactored
Renamed blue-main to blue-today because it is not our blue-main
Added a blue-light-2-transparency (blue-light-2 at a opacity of 25%) color to be used on button hovers
Added hover animation for tabs
Updated zebra stripe color
_This was all completed while consulting with Abena_

# Related Tickets

- [SAR-594](https://jira.amida-tech.com/browse/SAR-594)

# Other Repos' PR(s) Intended to Work With This PR

- None.

# How Things Worked (or Didn't) Before This PR
Styles needed to be updated.
You would sometimes accidentally click an invisible return button that was stretched across the entire page.

# How Things Work Now (And How to Test)
Styles should be more uniform.
Return to all measures button should still work.

# Readiness

1. [X] This PR passes all automated tests.
2. [X] This PR has no linting errors.
3. [X] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
