### PR TITLE
SAR-601 Download excel File from HERA

### DIFF
--- a/src/layouts/MemberReport.js
+++ b/src/layouts/MemberReport.js
@@ -64,7 +64,7 @@ function MemberReport({ id }) {
           </Typography>
           <Info infoText={generalInfoTip} />
         </Box>
-        <a href={exportUrl} target="_self" rel="noreferrer">
+        <a href={exportUrl} target="_blank" rel="noreferrer">
           <Button className="member-report__download-icon" startIcon={<FileDownloadIcon />}>
             <Typography variant="caption">
               Export

--- a/src/layouts/MemberReport.js
+++ b/src/layouts/MemberReport.js
@@ -64,7 +64,7 @@ function MemberReport({ id }) {
           </Typography>
           <Info infoText={generalInfoTip} />
         </Box>
-        <a href={exportUrl} rel="noreferrer">
+        <a href={exportUrl} target="_blank" rel="noreferrer">
           <Button className="member-report__download-icon" startIcon={<FileDownloadIcon />}>
             <Typography variant="caption">
               Export

--- a/src/layouts/MemberReport.js
+++ b/src/layouts/MemberReport.js
@@ -24,7 +24,7 @@ const measureAnalysisTip = 'Information about measurement compliance, from dates
 
 const axios = require('axios').default;
 
-const memberQueryUrl = new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}members/info/`);
+const memberInfoQueryUrl = new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}members/info/`);
 
 function MemberReport({ id }) {
   const { datastore } = useContext(DatastoreContext);
@@ -33,7 +33,7 @@ function MemberReport({ id }) {
   const [rowData, setRowData] = useState([]);
 
   useEffect(() => {
-    axios.get(`${memberQueryUrl}?memberId=${id}`)
+    axios.get(`${memberInfoQueryUrl}?memberId=${id}`)
       .then((res) => {
         setMemberInfo(res.data);
       });
@@ -50,6 +50,8 @@ function MemberReport({ id }) {
     }
   }, [datastore, memberInfo]);
 
+  const exportUrl = `${env.REACT_APP_HEDIS_MEASURE_API_URL}exports/member/?memberId=${memberInfo.memberId}`
+
   const coverage = memberInfo.coverage?.find((item) => item.status?.value === 'active');
 
   return (
@@ -62,11 +64,13 @@ function MemberReport({ id }) {
           </Typography>
           <Info infoText={generalInfoTip} />
         </Box>
-        <Button disabled className="member-report__download-icon" startIcon={<FileDownloadIcon />}>
-          <Typography variant="caption">
-            Export
-          </Typography>
-        </Button>
+        <a href={exportUrl} rel="noreferrer">
+          <Button className="member-report__download-icon" startIcon={<FileDownloadIcon />}>
+            <Typography variant="caption">
+              Export
+            </Typography>
+          </Button>
+        </a>
       </Box>
       <Box className="member-report__info-display">
         <Grid className="member-report__member-card">

--- a/src/layouts/MemberReport.js
+++ b/src/layouts/MemberReport.js
@@ -64,7 +64,7 @@ function MemberReport({ id }) {
           </Typography>
           <Info infoText={generalInfoTip} />
         </Box>
-        <a href={exportUrl} target="_blank" rel="noreferrer">
+        <a href={exportUrl} target="_self" rel="noreferrer">
           <Button className="member-report__download-icon" startIcon={<FileDownloadIcon />}>
             <Typography variant="caption">
               Export


### PR DESCRIPTION
# Related Tickets

- [SAR-601](https://amida.atlassian.net/browse/SAR-601)

# Other Repos' PR(s) Intended to Work With This PR

[SAR-625](https://github.com/amida-tech/saraswati-hedis-results-api/pull/56)

# How Things Worked (or Didn't) Before This PR

There were no member exports generated by HERA, and you couldn't download them from dash.

# How Things Work Now (And How to Test)

HERA now generates excel files with member reports for AAB. It can then serve them to the front end, which has the corresponding link inserted into the dash, along with dynamic link generation for each member profile.

Testing requires having the correlating HERA branch working with test data in your mongodb. You should simply be able to navigate to an AAB member and click "export" in the member reports page. 

**KNOWN ISSUES:**
- During the creation of this PR it was determined templates would need to be used. They're being added in a pollow up PR by Maud. 
- The AAB-centric report is being generified, and will use the template model in the future.

# Readiness

1. [x] This PR passes all automated tests.
2. [x] This PR has no linting errors.
3. [x] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
