### PR TITLE
SAR 652: fix summary testing

### DIFF
--- a/src/test/components/Summary/Summary.test.js
+++ b/src/test/components/Summary/Summary.test.js
@@ -107,7 +107,7 @@ describe('RatingTrends', () => {
       .length === 4).toBe(true);
   })
 
-  test('tests rendering functionality', () => {
+  test('tests rendering functionality if not loading', () => {
     render(
       <RatingTrends
         activeMeasure={mockActiveMeasure}

--- a/src/test/components/Summary/Summary.test.js
+++ b/src/test/components/Summary/Summary.test.js
@@ -3,6 +3,7 @@ import {
 } from '@testing-library/react';
 import { sortedTrendsCreator, mainTrendCreator } from '../../../components/Summary/RatingTrendsUtils';
 import Info from '../../../components/Common/Info';
+
 import TrendDisplay from '../../../components/Summary/TrendDisplay';
 import RatingTrends from '../../../components/Summary/RatingTrends';
 import Banner from '../../../components/Common/Banner'
@@ -112,8 +113,10 @@ describe('RatingTrends', () => {
         activeMeasure={mockActiveMeasure}
         info={mockDataStore.info}
         trends={mockTrends}
+        isLoading={false}
       />,
     )
+
     expect(screen.queryByText('Ratings & Trends')).not.toBeNull()
     expect(screen.queryByText('Composite Score % Change')).not.toBeNull()
     expect(screen.queryByText('Star Rating')).not.toBeNull()


### PR DESCRIPTION
# Related Tickets

- [SAR-652](https://jira.amida-tech.com/browse/SAR-652)

# Other Repos' PR(s) Intended to Work With This PR

None

# How Things Worked (or Didn't) Before This PR
The summary test was failing because it was missing the isLoading prop and trying to find elements that weren't loaded in yet

# How Things Work Now (And How to Test)
Run the test again, it should pass now that the isLoading in prop is accounted for

# Readiness

1. [X] This PR passes all automated tests.
2. [X] This PR has no linting errors.
3. [X] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
