### PR TITLE
Measure Links Moved to Hera

### DIFF
--- a/src/assets/styles/_measure-table-row.scss
+++ b/src/assets/styles/_measure-table-row.scss
@@ -48,5 +48,8 @@ $block-class: 'measure-table-row';
 
         }
         
+        &__alert-link{
+            font-style: italic;
+        }
     }
 }

--- a/src/components/ChartContainer/D3Container.js
+++ b/src/components/ChartContainer/D3Container.js
@@ -33,6 +33,7 @@ import {
   dashboardActionsProps,
   defaultActiveMeasure,
 } from './D3Props';
+
 import {
   filterByDOC,
   filterByPercentage,

--- a/src/components/DisplayTable/MeasureTableRow.js
+++ b/src/components/DisplayTable/MeasureTableRow.js
@@ -117,6 +117,8 @@ function MeasureTableRow({
                     You are now leaving Saraswati and entering a site hosted by
                     a different Federal agency or company. If you are not
                     automatically forwarded, please proceed to:
+                    {' '}
+                    {alertPath(rowDataItem.value).pathto}
                   </Alert>
 
                 </>

--- a/src/components/DisplayTable/MeasureTableRow.js
+++ b/src/components/DisplayTable/MeasureTableRow.js
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom';
 import Tooltip from '@mui/material/Tooltip';
 import CheckBoxCell from './CheckBoxCell';
 import Alert from '../Utilities/Alert'
-import { measureLinks } from '../Utilities/MeasureTable'
 
 function MeasureTableRow({
   rowDataItem, headerInfo, useCheckBox, handleCheckBoxEvent, rowSelected, color, measureInfo,
@@ -16,16 +15,20 @@ function MeasureTableRow({
 
   const alertTitle = 'Leaving Saraswati'
   const alertPath = (info) => {
-    const foundLinkInfo = measureLinks.filter((measureLink) => info.includes(measureLink.measure))
+    if (measureInfo[info].link) {
+      return {
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        pathto: measureInfo[info].link,
+      }
+    }
     return {
       target: '_blank',
       rel: 'noopener noreferrer',
-      pathto: foundLinkInfo[0].link,
+      pathto: null,
     }
   }
-
   const [openAlert, setOpenAlert] = useState(false);
-
   if (compositeCheck) {
     return (
       <Box className="measure-table-row">
@@ -114,8 +117,6 @@ function MeasureTableRow({
                     You are now leaving Saraswati and entering a site hosted by
                     a different Federal agency or company. If you are not
                     automatically forwarded, please proceed to:
-                    {/* {' '}
-                    {alertPath(rowDataItem.value).pathto} */}
                   </Alert>
 
                 </>

--- a/src/components/Utilities/Alert.js
+++ b/src/components/Utilities/Alert.js
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import {
-  Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle,
+  Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography,
 } from '@mui/material';
 
 export default function Alert({
@@ -28,9 +28,14 @@ export default function Alert({
       </DialogTitle>
 
       <DialogContent>
-        <DialogContentText sx={{ lineHeight: '2rem' }} id="alert-dialog-description">
+        <DialogContentText sx={{ lineHeight: '2rem', marginBottom: '1rem' }} id="alert-dialog-description">
           {children}
         </DialogContentText>
+        <Typography
+          className="measure-table-row__alert-link"
+        >
+          {options.pathto}
+        </Typography>
       </DialogContent>
 
       <DialogActions>

--- a/src/components/Utilities/Alert.js
+++ b/src/components/Utilities/Alert.js
@@ -31,11 +31,7 @@ export default function Alert({
         <DialogContentText sx={{ lineHeight: '2rem', marginBottom: '1rem' }} id="alert-dialog-description">
           {children}
         </DialogContentText>
-        <Typography
-          className="measure-table-row__alert-link"
-        >
-          {options.pathto}
-        </Typography>
+        
       </DialogContent>
 
       <DialogActions>

--- a/src/components/Utilities/MeasureTable.js
+++ b/src/components/Utilities/MeasureTable.js
@@ -6,31 +6,6 @@ const numeratorTip = 'The number of members who have satisfied the criteria for 
 const denominatorTip = 'The population of members who are eligible for this measure. Currently the same as Eligible Population.';
 const availableExclusionsTip = 'The population that can be excluded based on criteria.';
 
-const measureLinks = [
-  { measure: 'aab', link: 'https://www.ncqa.org/hedis/measures/avoidance-of-antibiotic-treatment-for-acute-bronchitis-bronchiolitis/' },
-  { measure: 'adde', link: 'https://www.ncqa.org/hedis/measures/follow-up-care-for-children-prescribed-adhd-medication/' },
-  { measure: 'aise', link: 'https://www.ncqa.org/hedis/measures/adult-immunization-status/' },
-  { measure: 'apme', link: 'https://www.ncqa.org/hedis/measures/metabolic-monitoring-for-children-and-adolescents-on-antipsychotics/' },
-  { measure: 'asfe', link: 'https://www.ncqa.org/hedis/measures/unhealthy-alcohol-use-screening-and-follow-up/' },
-  { measure: 'bcse', link: 'https://www.ncqa.org/hedis/measures/breast-cancer-screening/' },
-  { measure: 'ccs', link: 'https://www.ncqa.org/hedis/measures/cervical-cancer-screening/' },
-  { measure: 'cise', link: 'https://www.ncqa.org/hedis/measures/childhood-immunization-status/' },
-  { measure: 'cole', link: 'https://www.ncqa.org/hedis/measures/colorectal-cancer-screening/' },
-  { measure: 'cou', link: 'https://www.ncqa.org/hedis/measures/risk-of-continued-opioid-use/' },
-  { measure: 'cwp', link: 'https://www.ncqa.org/hedis/measures/appropriate-testing-for-pharyngitis/' },
-  { measure: 'dmse', link: 'https://www.ncqa.org/hedis/measures/utilization-of-the-phq-9-to-monitor-depression-symptoms-for-adolescents-and-adults/' },
-  { measure: 'drre', link: 'https://www.ncqa.org/hedis/measures/depression-remission-or-response-for-adolescents-and-adults/' },
-  { measure: 'dsfe', link: 'https://www.ncqa.org/hedis/measures/depression-screening-and-follow-up-for-adolescents-and-adults/' },
-  { measure: 'fum', link: 'https://www.ncqa.org/hedis/measures/follow-up-after-emergency-department-visit-for-mental-illness/' },
-  { measure: 'imae', link: 'https://www.ncqa.org/hedis/measures/immunizations-for-adolescents/' },
-  { measure: 'pdse', link: 'https://www.ncqa.org/hedis/measures/postpartum-depression-screening-and-follow-up/' },
-  { measure: 'pnde', link: 'https://www.ncqa.org/hedis/measures/prenatal-depression-screening-and-followup/' },
-  { measure: 'prse', link: 'https://www.ncqa.org/hedis/measures/prenatal-immunization-status/' },
-  { measure: 'psa', link: 'https://www.ncqa.org/hedis/measures/non-recommended-psa-based-screening-in-older-men/' },
-  { measure: 'uop', link: 'https://www.ncqa.org/hedis/measures/use-of-opioids-from-multiple-providers/' },
-  { measure: 'uri', link: 'https://www.ncqa.org/hedis/measures/appropriate-treatment-for-upper-respiratory-infection/' },
-]
-
 const pageSize = 10;
 
 const inclusions = {
@@ -127,5 +102,5 @@ const formatData = (currentResults) => {
 };
 
 module.exports = {
-  headerData, pageSize, formatData, measureLinks,
+  headerData, pageSize, formatData,
 };

--- a/src/context/DatastoreProvider.js
+++ b/src/context/DatastoreProvider.js
@@ -46,6 +46,7 @@ export default function DatastoreProvider({ children }) {
       const infoPromise = axios.get(infoUrl)
 
       Promise.all([searchPromise, infoPromise]).then((values) => {
+        console.log(values[1].data)
         datastoreActions.setResults(values[0].data, values[1].data);
         datastoreActions.setIsLoading(false);
       });

--- a/src/context/DatastoreProvider.js
+++ b/src/context/DatastoreProvider.js
@@ -46,7 +46,6 @@ export default function DatastoreProvider({ children }) {
       const infoPromise = axios.get(infoUrl)
 
       Promise.all([searchPromise, infoPromise]).then((values) => {
-        console.log(values[1].data)
         datastoreActions.setResults(values[0].data, values[1].data);
         datastoreActions.setIsLoading(false);
       });


### PR DESCRIPTION
# How Things Worked (or Didn't) Before This PR
-measure links was being handled on front end.

# How Things Work Now (And How to Test)
-measure links have been moved into hera.
-measure links now use "measureInfo" which is passed into "MeasureTableRow" as in "store.info".

# Readiness

1. [x] This PR passes all automated tests.
2. [x] This PR has no linting errors.
3. [x] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
