### PR TITLE
Dockerfile updates browser list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ COPY ./yarn.lock .
 RUN yarn install --frozen-lockfile && yarn cache clean
 # Up til this point should get cached and only re-run if dependencies change
 
+# Update browser list
+RUN npx browserslist@latest --update-db
+
 # Copy necessary files to build
 COPY . /app
 COPY ./public/index.html /app/public

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,9 +3634,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001400:
-  version "1.0.30001416"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz#29692af8a6a11412f2d3cf9a59d588fcdd21ce4c"
-  integrity sha512-06wzzdAkCPZO+Qm4e/eNghZBDfVNDsCgw33T27OwBH9unE9S478OYw//Q2L7Npf/zBzs7rjZOszIFQkwQKAEqA==
+  version "1.0.30001419"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz"
+  integrity sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Related Tickets

- [SAR-732](https://jira.amida-tech.com/browse/SAR-732)

# How Things Worked (or Didn't) Before This PR

Got this error when building the dockerfile or running `yarn build` locally

`Failed to load plugin 'jsx-a11y' declared in '.eslintrc.json': Invalid attempt to spread non-iterable instance.`
`2#12 75.75 In order to be iterable, non-array objects must have a [Symbol.iterator]() method.`
`3#12 75.75 Referenced from: /app/.eslintrc.json`

# How Things Work Now (And How to Test)

Now the dockerfile builds properly.
