### PR TITLE
Prevents crashing when missing measures

### DIFF
--- a/src/components/Utilities/RatingTrendValuesUtil.js
+++ b/src/components/Utilities/RatingTrendValuesUtil.js
@@ -99,7 +99,7 @@ export function percentDisplayValue(trends, preferences, activeMeasure, measureC
   } else {
     percentValue = trends.find(
       (trend) => trend.measure === preferences.measure.toLowerCase(),
-    ).percentChange;
+    )?.percentChange || 0;
   }
 
   let percentColor = theme.palette?.text.disabled;
@@ -122,7 +122,7 @@ export function percentDisplayValue(trends, preferences, activeMeasure, measureC
 export function starDisplayValue(currentResults, preferences) {
   const starValue = currentResults.find(
     (trend) => trend.measure === preferences.measure.toLowerCase(),
-  ).starRating;
+  )?.starRating || 0;
   return (
     <div aria-label={preferences.measure}>
       <Rating


### PR DESCRIPTION
# Related Tickets

- [SAR-877](https://jira.amida-tech.com/browse/SAR-877)

# Other Repos' PR(s) Intended to Work With This PR

- https://github.com/amida-tech/saraswati-hedis-results-api/pull/178

# How Things Worked (or Didn't) Before This PR
Small fix for the dashboard when missing HEDIS measures

# How Things Work Now (And How to Test)
Use the linked PR to generate data. After generating 2025, and only 2025, view the dashboard. It will only display the 2 measures that we have specified.

# Readiness

1. [ ] This PR passes all automated tests.
2. [ ] This PR has no linting errors.
3. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.


[SAR-877]: https://amida.atlassian.net/browse/SAR-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ