### PR TITLE
Measurement year selector

### DIFF
--- a/src/assets/styles/_banner.scss
+++ b/src/assets/styles/_banner.scss
@@ -5,11 +5,25 @@ $block-class: 'banner';
     .#{$block-class} {
         text-align: left;
         margin: 0 1rem 1rem 0;
+        width: 97%;
+
+        & &__header-container {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 0.5rem;
+        }
 
         & &__header {
-            margin-bottom: 0.5rem;
             font-size: 3rem;
             font-weight: 600;
+            margin-bottom: 0;
+        }
+
+        & &__year-selector {
+            display: flex;
+            align-items: center;
+            margin-left: 1rem;
         }
 
         & &__update-box {

--- a/src/components/Common/Banner.js
+++ b/src/components/Common/Banner.js
@@ -2,24 +2,30 @@ import { Box } from '@mui/system';
 import { Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 import theme from '../../assets/styles/AppTheme';
+import MeasurementYearSelector from './MeasurmentYearSelector';
 
 function Banner({ headerText, lastUpdated }) {
   return (
     <Box className="banner">
-      <Typography variant="h1" color={theme.palette?.bluegray.D2} className="banner__header">
-        { headerText }
-      </Typography>
-      { lastUpdated && (
-      <Box className="banner__update-box">
-        <Typography color={theme.palette?.bluegray.D1} className="banner__update-label">
-          Last Updated:
+      <Box className="banner__header-container">
+        <Typography variant="h1" color={theme.palette?.bluegray.D2} className="banner__header">
+          {headerText}
         </Typography>
-        <Typography color={theme.palette?.bluegray.L1} className="banner__update-time">
-          {' '}
-          {lastUpdated}
-        </Typography>
+        <Box className="banner__year-selector">
+          <MeasurementYearSelector />
+        </Box>
       </Box>
-      ) }
+      {lastUpdated && (
+        <Box className="banner__update-box">
+          <Typography color={theme.palette?.bluegray.D1} className="banner__update-label">
+            Last Updated:
+          </Typography>
+          <Typography color={theme.palette?.bluegray.L1} className="banner__update-time">
+            {' '}
+            {lastUpdated}
+          </Typography>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/components/Common/MeasurmentYearSelector.js
+++ b/src/components/Common/MeasurmentYearSelector.js
@@ -1,0 +1,69 @@
+import { useContext, useEffect } from 'react';
+import {
+  FormControl, InputLabel, Select, MenuItem,
+} from '@mui/material';
+import { DatastoreContext } from '../../context/DatastoreProvider';
+
+function MeasurementYearSelector() {
+  const { datastore, datastoreActions } = useContext(DatastoreContext);
+  const { measurementYear } = datastore;
+  const availableYears = [2022, 2025];
+
+  // check localStorage for saved year
+  useEffect(() => {
+    const storedYear = localStorage.getItem('selectedYear');
+
+    // Only update if there's a valid year in localStorage
+    if (storedYear && availableYears.includes(Number(storedYear))) {
+      datastoreActions.setMeasurementYear(Number(storedYear));
+    }
+  }, []);
+
+  const handleYearChange = (event) => {
+    const newYear = event.target.value;
+
+    datastoreActions.setMeasurementYear(newYear);
+
+    // Save to localStorage for persistence across pages and sessions
+    localStorage.setItem('selectedYear', newYear);
+  };
+
+  return (
+    <FormControl
+      variant="outlined"
+      size="small"
+      sx={{
+        minWidth: 180,
+        '& .MuiInputLabel-root': {
+          backgroundColor: 'white',
+          paddingRight: '8px',
+          paddingLeft: '4px',
+        },
+        '& .MuiOutlinedInput-notchedOutline': {
+          textAlign: 'left',
+          '& legend': {
+            maxWidth: '170px',
+          },
+        },
+      }}
+    >
+      <InputLabel id="measurement-year-select-label">Measurement Year</InputLabel>
+      <Select
+        labelId="measurement-year-select-label"
+        id="measurement-year-select"
+        value={measurementYear}
+        onChange={handleYearChange}
+        label="Year"
+        data-testid="measurement-year-selector"
+      >
+        {availableYears.map((year) => (
+          <MenuItem key={year} value={year}>
+            {year}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+export default MeasurementYearSelector;

--- a/src/context/DatastoreProvider.js
+++ b/src/context/DatastoreProvider.js
@@ -13,10 +13,10 @@ import { DatastoreReducer, initialState } from './DatastoreReducer';
 import env from '../env';
 
 const useLegacyResults = env.REACT_APP_LEGACY_RESULTS;
-const searchUrl = useLegacyResults === 'true'
-  ? new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}measures/searchResults`)
-  : new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}measures/dailyMeasureResults`);
-const trendUrl = new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}measures/trends?legacyResults=${useLegacyResults}`);
+const baseSearchUrl = useLegacyResults === 'true'
+  ? `${env.REACT_APP_HEDIS_MEASURE_API_URL}measures/searchResults`
+  : `${env.REACT_APP_HEDIS_MEASURE_API_URL}measures/dailyMeasureResults`;
+const baseTrendUrl = `${env.REACT_APP_HEDIS_MEASURE_API_URL}measures/trends`;
 const infoUrl = new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}measures/info`);
 const payorsUrl = new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}payors`);
 const healthcareProvidersUrl = new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}healthcareproviders`);
@@ -29,6 +29,7 @@ export const DatastoreContext = createContext(initialState);
 
 export default function DatastoreProvider({ children }) {
   const [datastore, dispatch] = useReducer(DatastoreReducer, initialState);
+  const { measurementYear } = datastore;
 
   const datastoreActions = useMemo(() => ({
     setResults: (results, info) => dispatch({
@@ -72,7 +73,19 @@ export default function DatastoreProvider({ children }) {
       payload: status,
     }),
 
+    setMeasurementYear: (year) => dispatch({
+      type: 'SET_MEASUREMENT_YEAR',
+      payload: year,
+    }),
+
   }), [dispatch]);
+
+  const searchUrl = new URL(baseSearchUrl);
+  searchUrl.searchParams.append('measurementYear', measurementYear);
+
+  const trendUrl = new URL(baseTrendUrl);
+  trendUrl.searchParams.append('measurementYear', measurementYear);
+  trendUrl.searchParams.append('legacyResults', useLegacyResults);
 
   useEffect(() => {
     if (devData === 'true') {
@@ -82,6 +95,7 @@ export default function DatastoreProvider({ children }) {
       datastoreActions.setIsLoading(false);
       datastoreActions.setStatus('200')
     } else {
+      datastoreActions.setIsLoading(true);
       const trendPromise = axios.get(trendUrl);
       const searchPromise = axios.get(searchUrl);
       const infoPromise = axios.get(infoUrl);
@@ -120,7 +134,7 @@ export default function DatastoreProvider({ children }) {
         datastoreActions.setStatus(error.request.status)
       });
     }
-  }, [datastoreActions]);
+  }, [datastoreActions, measurementYear]);
 
   const reducerValue = useMemo(() => ({
     datastore, datastoreActions,

--- a/src/context/DatastoreReducer.js
+++ b/src/context/DatastoreReducer.js
@@ -61,6 +61,7 @@ export const initialState = {
     healthcareCoverages: [],
     healthcarePractitioners: [],
   },
+  measurementYear: 2022,
 };
 
 export const DatastoreReducer = (state, action) => {
@@ -116,6 +117,11 @@ export const DatastoreReducer = (state, action) => {
       return {
         ...state,
         status: action.payload,
+      };
+    case 'SET_MEASUREMENT_YEAR':
+      return {
+        ...state,
+        measurementYear: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
- Added a dropdown to select measurement year 
- Persist selected year on local storage
- sends selected year as a filter parameter to the backend
- Test with back-end PR https://github.com/amida-tech/saraswati-hedis-results-api/pull/181