### PR TITLE
[SAR-899]: Keith Update

### DIFF
--- a/src/components/Chart/ChartContainer.js
+++ b/src/components/Chart/ChartContainer.js
@@ -80,7 +80,7 @@ function ChartContainer({
   selectedMeasures,
 }) {
   const {
-    datastore: { comparisonMode, comparisonResults, filterOptions },
+    datastore: { comparisonMode, comparisonResults },
   } = useContext(DatastoreContext);
 
   const handleFilterChange = (options) => {
@@ -115,7 +115,6 @@ function ChartContainer({
       colorMap,
       theme,
       comparisonMode,
-      filterOptions,
     );
     chartCategories = [
       ...new Set(comparisonResults.map((entry) => entry.date)),

--- a/src/components/Chart/ChartContainer.js
+++ b/src/components/Chart/ChartContainer.js
@@ -95,16 +95,15 @@ function ChartContainer({
   let chartSeries; let chartOptions; let chartCategories;
 
   const isComparison = comparisonMode
-    && comparisonMode !== 'Default'
+    && comparisonMode !== 'default'
     && Array.isArray(comparisonResults)
     && comparisonResults.length > 0;
 
   if (isComparison) {
     // --- COMPARISON MODE ---
-    const filterKey = Object.keys(filterOptions)
-      .find((k) => comparisonMode.toLowerCase().includes(k.toLowerCase()));
-    const comparisonItems = filterOptions?.[filterKey] || [];
-    const selectedComparisonItems = comparisonItems.map((item) => item.value);
+    const selectedComparisonItems = [
+      ...new Set(comparisonResults.map((entry) => entry.comparisonItem)),
+    ];
     const allSeries = selectedComparisonItems
       .map((value) => comparisonResults.find((item) => item.comparisonItem === value))
       .filter(Boolean);
@@ -162,7 +161,7 @@ function ChartContainer({
 
   return (
     <div className="chart-container">
-      {comparisonMode === 'Default' && (
+      {comparisonMode === 'default' && (
         <FilterDrawer
           filterDrawerOpen={filterDrawerOpen}
           toggleFilterDrawer={toggleFilterDrawer}

--- a/src/components/Chart/ChartHeader.js
+++ b/src/components/Chart/ChartHeader.js
@@ -17,7 +17,7 @@ function ChartHeader({
     datastore: { comparisonMode },
   } = useContext(DatastoreContext);
 
-  const chartTitle = comparisonMode === 'Default'
+  const chartTitle = comparisonMode === 'default'
     ? 'All Measures'
     : `Compare By ${comparisonMode} For ${activeMeasure.measure}`;
 
@@ -53,7 +53,7 @@ function ChartHeader({
     </Grid>
   );
 
-  return isComposite || comparisonMode !== 'Default' ? titleDisplay : linkDisplay;
+  return isComposite || comparisonMode !== 'default' ? titleDisplay : linkDisplay;
 }
 
 ChartHeader.propTypes = {

--- a/src/components/Chart/ComparisonSelector.js
+++ b/src/components/Chart/ComparisonSelector.js
@@ -14,13 +14,28 @@ import Notification from '../Common/Notification';
 import { DatastoreContext } from '../../context/DatastoreProvider';
 import env from '../../env';
 
-const comparisonModes = [
-  'Default',
-  'Payors',
-  'Providers',
-  'Coverage',
-  'Practitioners',
-];
+const newComparisonModes = [
+  {
+    label: 'Default',
+    value: 'default',
+  },
+  {
+    label: 'Payors',
+    value: 'payors',
+  },
+  {
+    label: 'Providers',
+    value: 'healthcareProviders',
+  },
+  {
+    label: 'Coverage',
+    value: 'healthcareCoverages',
+  },
+  {
+    label: 'Practitioners',
+    value: 'healthcarePractitioners',
+  },
+]
 
 export default function ComparisonSelector({ activeMeasure, handleResetData, setIsLoading }) {
   const {
@@ -33,25 +48,18 @@ export default function ComparisonSelector({ activeMeasure, handleResetData, set
   } = useContext(DatastoreContext);
   const [error, setError] = useState(undefined);
 
-  const aliasObj = {
-    payors: 'Payors',
-    healthcareProviders: 'Providers',
-    healthcareCoverages: 'Coverage',
-    healthcarePractitioners: 'Practitioners',
-  };
-
   const handleChange = async (e) => {
     const mode = e.target.value;
     setComparisonMode(mode);
     
-    if (mode === 'Default') {
+    if (mode === 'default') {
       setIsLoading(true)
       handleResetData();
     } else {
       const comparisonBody = {
         measurementYear,
         measurementType: activeMeasure.measure,
-        compareOption: Object.keys(aliasObj).find((k) => aliasObj[k] === mode),
+        compareOption: mode,
       } 
   
       const comparisonURL = new URL(`${env.REACT_APP_HEDIS_MEASURE_API_URL}/measures/compare`);
@@ -78,14 +86,14 @@ export default function ComparisonSelector({ activeMeasure, handleResetData, set
         <Select
           labelId="comparison-select-label"
           id="comparison-select"
-          value={comparisonMode || 'Default'}
+          value={comparisonMode || 'default'}
           onChange={handleChange}
           label="Comparison Mode"
           data-testid="comparison-selector"
         >
-          {comparisonModes.map((mode) => (
-            <MenuItem key={mode} value={mode}>
-              {mode}
+          {newComparisonModes.map((mode) => (
+            <MenuItem key={mode.value} value={mode.value}>
+              {mode.label}
             </MenuItem>
           ))}
         </Select>

--- a/src/components/Chart/ComparisonSelector.js
+++ b/src/components/Chart/ComparisonSelector.js
@@ -14,7 +14,7 @@ import Notification from '../Common/Notification';
 import { DatastoreContext } from '../../context/DatastoreProvider';
 import env from '../../env';
 
-const newComparisonModes = [
+const comparisonModes = [
   {
     label: 'Default',
     value: 'default',
@@ -91,7 +91,7 @@ export default function ComparisonSelector({ activeMeasure, handleResetData, set
           label="Comparison Mode"
           data-testid="comparison-selector"
         >
-          {newComparisonModes.map((mode) => (
+          {comparisonModes.map((mode) => (
             <MenuItem key={mode.value} value={mode.value}>
               {mode.label}
             </MenuItem>

--- a/src/components/Chart/MeasurementYearSelector.js
+++ b/src/components/Chart/MeasurementYearSelector.js
@@ -22,7 +22,7 @@ function MeasurementYearSelector() {
     <FormControl
       variant="outlined"
       size="small"
-      disabled={datastore.comparisonMode !== 'Default'} // only for now
+      disabled={datastore.comparisonMode !== 'default'} // only for now
       sx={{
         minWidth: 180,
         '& .MuiInputLabel-root': {

--- a/src/components/Common/Controller.js
+++ b/src/components/Common/Controller.js
@@ -101,7 +101,6 @@ export async function filterSearch(searchMeasure, searchArrayOrFilters, isCompos
       dailyMeasureResults: [],
     };
   } catch (err) {
-    console.error('filterSearch error:', err);
     return {
       status: 'Failed',
       members: [],

--- a/src/components/Utilities/ChartUtils.js
+++ b/src/components/Utilities/ChartUtils.js
@@ -166,7 +166,7 @@ export const displayDataFormatter = (
   if (!Array.isArray(currentResults)) return [];
 
   // COMPARISON MODE
-  if (comparisonMode && comparisonMode !== 'Default') {
+  if (comparisonMode && comparisonMode !== 'default') {
     const uniqueDates = [
       ...new Set(displayData.map((entry) => entry.date)),
     ].sort();
@@ -191,7 +191,7 @@ export const displayDataFormatter = (
       });
       if (yValues.some((v) => v !== null)) {
         series.push({
-          name: createSeriesName(key, comparisonMode, filterOptions),
+          name: key,
           color: colorMap.find((color) => color.value === key)?.color
             || theme.palette?.primary.main,
           data: yValues,

--- a/src/components/Utilities/ChartUtils.js
+++ b/src/components/Utilities/ChartUtils.js
@@ -133,27 +133,6 @@ export const calcMemberResults = (dailyMeasureResults, measureInfo = {}) => {
   return { results: dailyMeasureResults, currentResults };
 };
 
-function createSeriesName(comparisonItem, comparisonMode, filterOptions) {
-  if (!comparisonItem || !filterOptions || !comparisonMode) return comparisonItem;
-
-  const aliasObj = {
-    Payors: 'payors',
-    Providers: 'healthcareProviders',
-    Coverage: 'healthcareCoverages',
-    Practitioners: 'healthcarePractitioners',
-  };
-  const optionsKey = aliasObj[comparisonMode] || comparisonMode?.toLowerCase();
-  const list = filterOptions[optionsKey];
-  if (!list) return comparisonItem;
-  const labelFields = ['payor', 'provider', 'coverage', 'practitioner'];
-  const match = list.find((opt) => opt.value === comparisonItem);
-  if (!match) return comparisonItem;
-  for (const field of labelFields) {
-    if (match[field]) return match[field];
-  }
-  return comparisonItem;
-}
-
 export const displayDataFormatter = (
   currentResults,
   selectedMeasures,
@@ -161,7 +140,6 @@ export const displayDataFormatter = (
   colorMap,
   theme,
   comparisonMode,
-  filterOptions,
 ) => {
   if (!Array.isArray(currentResults)) return [];
 

--- a/src/context/DatastoreReducer.js
+++ b/src/context/DatastoreReducer.js
@@ -65,7 +65,7 @@ export const initialState = {
     const stored = parseInt(localStorage.getItem('selectedYear'), 10);
     return [2022, 2025].includes(stored) ? stored : 2022;
   })(),
-  comparisonMode: 'Default',
+  comparisonMode: 'default',
 };
 
 export const DatastoreReducer = (state, action) => {

--- a/src/layouts/Dashboard.js
+++ b/src/layouts/Dashboard.js
@@ -85,7 +85,7 @@ export default function Dashboard() {
   // CLEANS SLATE FUNCTION
   const handleResetData = (router) => {
     scrollTop();
-    datastoreActions.setComparisonMode('Default');
+    datastoreActions.setComparisonMode('default');
     if (router === undefined) {
       setIsLoading(true);
       setCurrentTimeline(datastore.defaultTimelineState);
@@ -101,7 +101,7 @@ export default function Dashboard() {
           filters: {},
         });
         setIsComposite(true);
-        datastoreActions.setComparisonMode('Default');
+        datastoreActions.setComparisonMode('default');
         setDisplayData(datastore.results.map((result) => ({ ...result })));
         setCurrentResults(datastore.currentResults);
         setSelectedMeasures(Object.keys(datastore.info));
@@ -148,7 +148,7 @@ export default function Dashboard() {
           setDisplayData(filterInfo.results.map((result) => ({ ...result })));
         }
         setIsComposite(true);
-        datastoreActions.setComparisonMode('Default');
+        datastoreActions.setComparisonMode('default');
         setFilterDisabled(false);
         setTableFilter([]);
         setRowEntries([]);
@@ -209,7 +209,7 @@ export default function Dashboard() {
           filters: {},
         });
         setIsComposite(true);
-        datastoreActions.setComparisonMode('Default');
+        datastoreActions.setComparisonMode('default');
         setDisplayData(datastore.results.map((result) => ({ ...result })));
         setCurrentResults(datastore.currentResults);
         setSelectedMeasures(datastore.currentResults.map((result) => result.measure));
@@ -274,7 +274,7 @@ export default function Dashboard() {
           setDisplayData(filterInfo.results.map((result) => ({ ...result })));
         }
         setIsComposite(true);
-        datastoreActions.setComparisonMode('Default');
+        datastoreActions.setComparisonMode('default');
         setColorMap(ColorMapping(filterInfo.currentResults));
         setFilterDisabled(false);
         setTableFilter([]);
@@ -374,65 +374,65 @@ export default function Dashboard() {
     tableFilter,
   ]);
 
-  useEffect(() => {
-  // only run when entering a real comparison mode
-    if (!datastore.comparisonMode || datastore.comparisonMode === 'Default') {
-      return;
-    }
+  // useEffect(() => {
+  // // only run when entering a real comparison mode
+  //   if (!datastore.comparisonMode || datastore.comparisonMode === 'Default') {
+  //     return;
+  //   }
 
-    let didCancel = false;
-    const aliasObj = {
-      payors: 'Payors',
-      healthcareProviders: 'Providers',
-      healthcareCoverages: 'Coverages',
-      healthcarePractitioners: 'Practitioners',
-    };
+  //   let didCancel = false;
+  //   const aliasObj = {
+  //     payors: 'Payors',
+  //     healthcareProviders: 'Providers',
+  //     healthcareCoverages: 'Coverages',
+  //     healthcarePractitioners: 'Practitioners',
+  //   };
 
-    async function loadComparisonData() {
-      setIsLoading(true);
-      const filterKey = Object.entries(aliasObj)
-        .find(([, label]) => label === datastore.comparisonMode)?.[0];
-      const items = filterKey ? (datastore.filterOptions[filterKey] || []) : [];
-      const allResults = [];
+  //   async function loadComparisonData() {
+  //     setIsLoading(true);
+  //     const filterKey = Object.entries(aliasObj)
+  //       .find(([, label]) => label === datastore.comparisonMode)?.[0];
+  //     const items = filterKey ? (datastore.filterOptions[filterKey] || []) : [];
+  //     const allResults = [];
 
-      for (const item of items) {
-        const search = await filterSearch(
-          false,
-          [item.value],
-          isComposite,
-          datastore.measurementYear,
-        );
-        allResults.push(
-          ...search.dailyMeasureResults.map((r) => ({ ...r, measure: item.value })),
-        );
-      }
+  //     for (const item of items) {
+  //       const search = await filterSearch(
+  //         false,
+  //         [item.value],
+  //         isComposite,
+  //         datastore.measurementYear,
+  //       );
+  //       allResults.push(
+  //         ...search.dailyMeasureResults.map((r) => ({ ...r, measure: item.value })),
+  //       );
+  //     }
 
-      if (!didCancel) {
-        setCurrentResults(allResults);
-        setDisplayData(allResults);
-        setSelectedMeasures(items.map((i) => i.value));
-        setIsLoading(false);
-      }
-    }
+  //     if (!didCancel) {
+  //       setCurrentResults(allResults);
+  //       setDisplayData(allResults);
+  //       setSelectedMeasures(items.map((i) => i.value));
+  //       setIsLoading(false);
+  //     }
+  //   }
 
-    loadComparisonData();
+  //   loadComparisonData();
 
-    // eslint-disable-next-line consistent-return
-    return () => {
-      didCancel = true;
-    };
-  }, [
-    datastore.comparisonMode,
-    isComposite,
-    datastore.measurementYear,
-  ]);
+  //   // eslint-disable-next-line consistent-return
+  //   return () => {
+  //     didCancel = true;
+  //   };
+  // }, [
+  //   datastore.comparisonMode,
+  //   isComposite,
+  //   datastore.measurementYear,
+  // ]);
 
   // FORMATS DATA FOR CHART COMPONENT
   const chartDataGenerator = useCallback(() => {
     setIsLoading(true);
     let newChartData = [];
 
-    if (datastore.comparisonMode && datastore.comparisonMode !== 'Default') {
+    if (datastore.comparisonMode && datastore.comparisonMode !== 'default') {
       newChartData = displayDataFormatter(
         currentResults,
         selectedMeasures,
@@ -643,7 +643,7 @@ export default function Dashboard() {
       setFilterInfo(newFilterInfo);
       if (direction) {
         setIsComposite(true);
-        datastoreActions.setComparisonMode('Default');
+        datastoreActions.setComparisonMode('default');
       }
       setFilterActivated(true);
     } else {
@@ -787,7 +787,7 @@ export default function Dashboard() {
                 )}
             </Grid>
             <Grid item xs={12}>
-              { isLoading || (datastore.comparisonMode !== 'Default')
+              { isLoading || (datastore.comparisonMode !== 'default')
                 ? <div />
                 : (
                   <div className="chart-container">

--- a/src/layouts/Dashboard.js
+++ b/src/layouts/Dashboard.js
@@ -440,7 +440,6 @@ export default function Dashboard() {
         colorMap,
         theme,
         datastore.comparisonMode,
-        datastore.filterOptions,
       );
     }
     else if (

--- a/src/layouts/Dashboard.js
+++ b/src/layouts/Dashboard.js
@@ -374,59 +374,6 @@ export default function Dashboard() {
     tableFilter,
   ]);
 
-  // useEffect(() => {
-  // // only run when entering a real comparison mode
-  //   if (!datastore.comparisonMode || datastore.comparisonMode === 'Default') {
-  //     return;
-  //   }
-
-  //   let didCancel = false;
-  //   const aliasObj = {
-  //     payors: 'Payors',
-  //     healthcareProviders: 'Providers',
-  //     healthcareCoverages: 'Coverages',
-  //     healthcarePractitioners: 'Practitioners',
-  //   };
-
-  //   async function loadComparisonData() {
-  //     setIsLoading(true);
-  //     const filterKey = Object.entries(aliasObj)
-  //       .find(([, label]) => label === datastore.comparisonMode)?.[0];
-  //     const items = filterKey ? (datastore.filterOptions[filterKey] || []) : [];
-  //     const allResults = [];
-
-  //     for (const item of items) {
-  //       const search = await filterSearch(
-  //         false,
-  //         [item.value],
-  //         isComposite,
-  //         datastore.measurementYear,
-  //       );
-  //       allResults.push(
-  //         ...search.dailyMeasureResults.map((r) => ({ ...r, measure: item.value })),
-  //       );
-  //     }
-
-  //     if (!didCancel) {
-  //       setCurrentResults(allResults);
-  //       setDisplayData(allResults);
-  //       setSelectedMeasures(items.map((i) => i.value));
-  //       setIsLoading(false);
-  //     }
-  //   }
-
-  //   loadComparisonData();
-
-  //   // eslint-disable-next-line consistent-return
-  //   return () => {
-  //     didCancel = true;
-  //   };
-  // }, [
-  //   datastore.comparisonMode,
-  //   isComposite,
-  //   datastore.measurementYear,
-  // ]);
-
   // FORMATS DATA FOR CHART COMPONENT
   const chartDataGenerator = useCallback(() => {
     setIsLoading(true);


### PR DESCRIPTION
This is my attempt to simplify the madness.

1. Removed the useEffect that was using filters to collect the data to compare
2. Standardized the dropdown values and labels used for comparison mode
3. Used the data's `comparisonItem` to create the keys.

One thing I was trying to avoid is relying on locally cached filter options. Especially in this case we are making a call to the database, we can just get them there. Also I wanted to standardize the compare options. There were multiple arrays containing the information but now it's just one and it has everything.

Everything appears to be working for me, but we can talk about this more tomorrow.