### PR TITLE
Comparison mode now works with composite scores

### DIFF
--- a/src/components/Chart/ComparisonSelector.js
+++ b/src/components/Chart/ComparisonSelector.js
@@ -1,6 +1,6 @@
 /* eslint-disable consistent-return */
 /* eslint-disable no-restricted-syntax */
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext } from 'react';
 import {
   FormControl,
   InputLabel,
@@ -9,7 +9,6 @@ import {
 } from '@mui/material';
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import { filterSearch } from '../Common/Controller';
 import Notification from '../Common/Notification';
 import { DatastoreContext } from '../../context/DatastoreProvider';
 import env from '../../env';
@@ -42,74 +41,17 @@ export const comparisonModeLabels = [
 ]
 
 function ComparisonSelector({
-  activeMeasure, handleResetData, isComposite, setIsLoading,
-  setDisplayData, setSelectedMeasures, setCurrentResults,
+  activeMeasure, handleResetData, setIsLoading,
 }) {
   const {
     datastore: {
-      measurementYear, comparisonMode, filterOptions,
+      measurementYear, comparisonMode,
     },
     datastoreActions: {
       setComparisonResults, setComparisonMode,
     },
   } = useContext(DatastoreContext);
   const [error, setError] = useState(undefined);
-
-  const aliasObj = {
-    payors: 'Payors',
-    healthcareProviders: 'Providers',
-    healthcareCoverages: 'Coverage',
-    healthcarePractitioners: 'Practitioners',
-  };
-
-  // handles dailyMeasureResults in comparison mode no matter what,
-  // even if you were changing the year, went composite view to submeasure view,
-  // are in the member table view, anything that isn't expressly the selection dropdown
-  useEffect(() => {
-    if (!comparisonMode || comparisonMode === 'Default') {
-      return;
-    }
-
-    let didCancel = false;
-
-    const fetchFreshData = async () => {
-      setIsLoading(true);
-      const filterKey = Object.entries(aliasObj)
-        .find(([, label]) => label === comparisonMode)?.[0];
-      const items = filterKey ? (filterOptions[filterKey] || []) : [];
-      const allResults = [];
-
-      for (const item of items) {
-        // eslint-disable-next-line no-await-in-loop
-        const search = await filterSearch(
-          false,
-          [item.value],
-          isComposite,
-          measurementYear,
-        );
-        allResults.push(
-          ...search.dailyMeasureResults.map((r) => ({ ...r, measure: item.value })),
-        );
-      }
-
-      if (!didCancel) {
-        setCurrentResults(allResults);
-        setDisplayData(allResults);
-        setSelectedMeasures(items.map((i) => i.value));
-        setIsLoading(false);
-      }
-    }
-
-    fetchFreshData();
-
-    return () => {
-      didCancel = true;
-    };
-  }, [
-    comparisonMode,
-    isComposite,
-    measurementYear,
-  ]);
 
   const handleChange = async (e) => {
     const mode = e.target.value;
@@ -172,20 +114,12 @@ ComparisonSelector.propTypes = {
     measure: PropTypes.string,
   }),
   setIsLoading: PropTypes.func,
-  isComposite: PropTypes.bool,
-  setDisplayData: PropTypes.func,
-  setSelectedMeasures: PropTypes.func,
-  setCurrentResults: PropTypes.func,
 };
 
 ComparisonSelector.defaultProps = {
   handleResetData: () => {},
   activeMeasure: '',
   setIsLoading: false,
-  isComposite: false,
-  setDisplayData: {},
-  setSelectedMeasures: () => {},
-  setCurrentResults: () => {},
 };
 
 export default ComparisonSelector;

--- a/src/components/Common/Banner.js
+++ b/src/components/Common/Banner.js
@@ -1,7 +1,6 @@
 import { Box } from '@mui/system';
 import { Typography } from '@mui/material';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
 import ComparisonSelector from '../Chart/ComparisonSelector';
 import theme from '../../assets/styles/AppTheme';
 import MeasurementYearSelector from '../Chart/MeasurementYearSelector';
@@ -11,12 +10,6 @@ function Banner({
   setIsLoading, isComposite, setDisplayData, setSelectedMeasures,
   setCurrentResults,
 }) {
-  const { pathname } = useLocation();
-
-  const isRoot = pathname === '/';
-  const isMeasure = /^\/[^/]+$/.test(pathname);
-  const showComparison = !isRoot || isMeasure;
-
   return (
     <Box className="banner">
       <Box className="banner__header-container">
@@ -28,19 +21,17 @@ function Banner({
           {headerText}
         </Typography>
 
-        {showComparison && (
-          <Box className="banner__comparison-selector">
-            <ComparisonSelector
-              activeMeasure={activeMeasure}
-              handleResetData={handleResetData}
-              setIsLoading={setIsLoading}
-              isComposite={isComposite}
-              setDisplayData={setDisplayData}
-              setSelectedMeasures={setSelectedMeasures}
-              setCurrentResults={setCurrentResults}
-            />
-          </Box>
-        )}
+        <Box className="banner__comparison-selector">
+          <ComparisonSelector
+            activeMeasure={activeMeasure}
+            handleResetData={handleResetData}
+            setIsLoading={setIsLoading}
+            isComposite={isComposite}
+            setDisplayData={setDisplayData}
+            setSelectedMeasures={setSelectedMeasures}
+            setCurrentResults={setCurrentResults}
+          />
+        </Box>
 
         <Box className="banner__year-selector">
           <MeasurementYearSelector />
@@ -85,13 +76,13 @@ Banner.propTypes = {
 Banner.defaultProps = {
   headerText: '',
   lastUpdated: '',
-  handleResetData: () => {},
+  handleResetData: () => { },
   activeMeasure: '',
   setIsLoading: false,
   isComposite: false,
   setDisplayData: {},
-  setSelectedMeasures: () => {},
-  setCurrentResults: () => {},
+  setSelectedMeasures: () => { },
+  setCurrentResults: () => { },
 };
 
 export default Banner;

--- a/src/components/Utilities/ChartUtils.js
+++ b/src/components/Utilities/ChartUtils.js
@@ -395,6 +395,7 @@ export const lineChartOptions = ({
     show: true,
     showAlways: true,
     max: Array.isArray(safeChartData.data) && safeChartData.data.length > 0 ? 100 : undefined,
+    min: 0,
     tickAmount: 5,
     labels: {
       show: true,

--- a/src/layouts/Dashboard.js
+++ b/src/layouts/Dashboard.js
@@ -209,7 +209,6 @@ export default function Dashboard() {
           filters: {},
         });
         setIsComposite(true);
-        datastoreActions.setComparisonMode('default');
         setDisplayData(datastore.results.map((result) => ({ ...result })));
         setCurrentResults(datastore.currentResults);
         setSelectedMeasures(datastore.currentResults.map((result) => result.measure));


### PR DESCRIPTION
I couldn't help myself, I wanted to see if it worked. Funny, most of the changes was just removing checks if it's composite or not.

I also set the y-axis of the chart to always start at 0. It seemed like it should have been there from the start?